### PR TITLE
Load debug assets from external directory

### DIFF
--- a/.github/workflows/drive_assets.yml
+++ b/.github/workflows/drive_assets.yml
@@ -1,0 +1,81 @@
+name: Drive → Asset Map → Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      drive_link:
+        description: "Public Google Drive link (file or folder)"
+        required: true
+      release_tag:
+        description: "Release tag to upload originals (e.g. assets-pack-1)"
+        required: true
+      palette_url:
+        description: "Palette URL (COLOR.PAL/.gpl/.act). Optional"
+        required: false
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write    # коммит превью/манифеста и публикация релиза
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pillow gdown
+          sudo apt-get update && sudo apt-get install -y p7zip-full
+
+      - name: Download from Google Drive
+        run: |
+          mkdir -p dl
+          # gdown понимает и файл, и папку (если ссылка на папку)
+          gdown '${{ github.event.inputs.drive_link }}' -O dl --folder --remaining-ok || \
+          gdown '${{ github.event.inputs.drive_link }}' -O dl
+
+      - name: Fetch palette (optional)
+        if: ${{ inputs.palette_url != '' }}
+        run: |
+          curl -L '${{ inputs.palette_url }}' -o dl/palette.pal || true
+
+      - name: Add FR parser + map builder
+        run: |
+          cat > build_asset_map.py << 'PY'
+          # (вставлен генератор asset_map + превью, как я давал ранее)
+          # Сократил здесь для компактности. Я пришлю тебе полной версией отдельным файлом,
+          # или просто скопируй целиком из предыдущего сообщения и вставь сюда.
+          PY
+
+      - name: Build previews + asset_map.json
+        run: |
+          mkdir -p out
+          PAL=$(ls dl/palette* 2>/dev/null | head -n1 || true)
+          if [ -z "$PAL" ]; then
+            # если палитру не дали — создадим «псевдо»-gpl с серой гаммой (чтобы превью не падали)
+            printf "GIMP Palette\n" > dl/fallback.gpl
+            for i in $(seq 0 255); do echo "$i $i $i"; done >> dl/fallback.gpl
+            PAL=dl/fallback.gpl
+          fi
+          python build_asset_map.py --root dl --palette "$PAL" --out out
+
+      - name: Commit asset map + previews to repo
+        run: |
+          set -e
+          mkdir -p assets_preview
+          rsync -a out/previews/ assets_preview/ || true
+          cp out/asset_map.json asset_map.json
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add asset_map.json assets_preview || true
+          git commit -m "asset_map + previews (from Drive)" || echo "No changes to commit"
+          git push
+
+      - name: Create/Update release and upload originals
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag='${{ inputs.release_tag }}'
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" -t "$tag" -n "Original FR assets"
+          gh release upload "$tag" dl/** --clobber

--- a/.github/workflows/drive_assets.yml
+++ b/.github/workflows/drive_assets.yml
@@ -1,4 +1,4 @@
-name: Drive → Asset Map → Release
+name: Drive → Sort FR assets → Release (with built-in palette)
 
 on:
   workflow_dispatch:
@@ -7,18 +7,22 @@ on:
         description: "Public Google Drive link (file or folder)"
         required: true
       release_tag:
-        description: "Release tag to upload originals (e.g. assets-pack-1)"
+        description: "Release tag (e.g. assets-pack-1)"
         required: true
-      palette_url:
-        description: "Palette URL (COLOR.PAL/.gpl/.act). Optional"
+      export_kind:
+        description: "frames or spritesheet"
         required: false
-        default: ""
+        default: "frames"
+      make_gif:
+        description: "true/false: also create tiny gifs per asset"
+        required: false
+        default: "false"
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write    # коммит превью/манифеста и публикация релиза
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
@@ -31,51 +35,484 @@ jobs:
       - name: Download from Google Drive
         run: |
           mkdir -p dl
-          # gdown понимает и файл, и папку (если ссылка на папку)
-          gdown '${{ github.event.inputs.drive_link }}' -O dl --folder --remaining-ok || \
-          gdown '${{ github.event.inputs.drive_link }}' -O dl
+          gdown '${{ inputs.drive_link }}' -O dl --folder --remaining-ok || gdown '${{ inputs.drive_link }}' -O dl
 
-      - name: Fetch palette (optional)
-        if: ${{ inputs.palette_url != '' }}
+      - name: Write extractor
         run: |
-          curl -L '${{ inputs.palette_url }}' -o dl/palette.pal || true
+          cat > fr_extract_and_sort.py << 'PY'
+          #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Разбирает все *.FR* (FRM/FR1/...) в папке: декодирует, раскрашивает встроенной палитрой,
+# классифицирует и раскладывает по папкам: assets_out/<kind>/<category>/<name>/{dir_0/.../frame_00.png}
+# Дополнительно пишет assets_out/asset_map.json (минимум).
+# Требует: pip install pillow
 
-      - name: Add FR parser + map builder
-        run: |
-          cat > build_asset_map.py << 'PY'
-          # (вставлен генератор asset_map + превью, как я давал ранее)
-          # Сократил здесь для компактности. Я пришлю тебе полной версией отдельным файлом,
-          # или просто скопируй целиком из предыдущего сообщения и вставь сюда.
+import argparse, struct, re, json, os
+from pathlib import Path
+from PIL import Image
+
+# ---------- Вшитая GIMP-палитра (256 цветов) ----------
+_GPL = """GIMP Palette
+Name: !Fallout
+Columns: 16
+#
+ 0 0 255
+236 236 236
+220 220 220
+204 204 204
+188 188 188
+176 176 176
+160 160 160
+144 144 144
+128 128 128
+116 116 116
+100 100 100
+ 84 84 84
+ 72 72 72
+ 56 56 56
+ 40 40 40
+ 32 32 32
+252 236 236
+236 216 216
+220 196 196
+208 176 176
+192 160 160
+176 144 144
+164 128 128
+148 112 112
+132 96 96
+120 84 84
+104 68 68
+ 88 56 56
+ 76 44 44
+ 60 36 36
+ 44 24 24
+ 32 16 16
+236 236 252
+216 216 236
+196 196 220
+176 176 208
+160 160 192
+144 144 176
+128 128 164
+112 112 148
+ 96 96 132
+ 84 84 120
+ 68 68 104
+ 56 56 88
+ 44 44 76
+ 36 36 60
+ 24 24 44
+ 16 16 32
+252 176 240
+196 96 168
+104 36 96
+ 76 20 72
+ 56 12 52
+ 40 16 36
+ 36 4 36
+ 28 12 24
+252 252 200
+252 252 124
+228 216 12
+204 184 28
+184 156 40
+164 136 48
+144 120 36
+124 104 24
+108 88 16
+ 88 72 8
+ 72 56 4
+ 52 40 0
+ 32 24 0
+216 252 156
+180 216 132
+152 184 112
+120 152 92
+ 92 120 72
+ 64 88 52
+ 40 56 32
+112 96 80
+ 84 72 52
+ 56 48 32
+104 120 80
+112 120 32
+112 104 40
+ 96 96 36
+ 76 68 36
+ 56 48 32
+156 172 156
+120 148 120
+ 88 124 88
+ 64 104 64
+ 56 88 88
+ 48 76 72
+ 40 68 60
+ 32 60 44
+ 28 48 36
+ 20 40 24
+ 16 32 16
+ 24 48 24
+ 16 36 12
+ 8 28 4
+ 4 20 0
+ 4 12 0
+140 156 156
+120 148 152
+100 136 148
+ 80 124 144
+ 64 108 140
+ 48 88 140
+ 44 76 124
+ 40 68 108
+ 32 56 92
+ 28 48 76
+ 24 40 64
+156 164 164
+ 56 72 104
+ 80 88 88
+ 88 104 132
+ 56 64 80
+188 188 188
+172 164 152
+160 144 124
+148 124 96
+136 104 76
+124 88 52
+112 72 36
+100 60 20
+ 88 48 8
+252 204 204
+252 176 176
+252 152 152
+252 124 124
+252 100 100
+252 72 72
+252 48 48
+252 0 0
+224 0 0
+196 0 0
+168 0 0
+144 0 0
+116 0 0
+ 88 0 0
+ 64 0 0
+252 224 200
+252 196 148
+252 184 120
+252 172 96
+252 156 72
+252 148 44
+252 136 20
+252 124 0
+220 108 0
+192 96 0
+164 80 0
+132 68 0
+104 52 0
+ 76 36 0
+ 48 24 0
+248 212 164
+216 176 120
+200 160 100
+188 144 84
+172 128 68
+156 116 52
+140 100 40
+124 88 28
+112 76 20
+ 96 64 8
+ 80 52 4
+ 64 40 0
+ 52 32 0
+252 228 184
+232 200 152
+212 172 124
+196 144 100
+176 116 76
+160 92 56
+144 76 44
+132 60 32
+120 44 24
+108 32 16
+ 92 20 8
+ 72 12 4
+ 60 4 0
+252 232 220
+248 212 188
+244 192 160
+240 176 132
+240 160 108
+240 148 92
+216 128 84
+192 112 72
+168 96 64
+144 80 56
+120 64 48
+ 96 48 36
+ 72 36 28
+ 56 24 20
+100 228 100
+ 20 152 20
+ 0 164 0
+ 80 80 72
+ 0 108 0
+140 140 132
+ 28 28 28
+104 80 56
+ 48 40 32
+140 112 96
+ 72 56 40
+ 12 12 12
+ 60 60 60
+108 116 108
+120 132 120
+136 148 136
+148 164 148
+ 88 104 96
+ 96 112 104
+ 60 248 0
+ 56 212 8
+ 52 180 16
+ 48 148 20
+ 40 116 24
+252 252 252
+240 236 208
+208 184 136
+152 124 80
+104 88 60
+ 80 64 36
+ 52 40 28
+ 24 16 12
+ 0 0 0
+ 0 108 0
+ 11 115 7
+ 27 123 15
+ 43 131 27
+107 107 111
+ 99 103 127
+ 87 107 143
+ 0 147 163
+107 187 255
+255 0 0
+215 0 0
+147 43 11
+255 119 0
+255 59 0
+ 71 0 0
+123 0 0
+179 0 0
+123 0 0
+ 71 0 0
+ 83 63 43
+ 75 59 43
+ 67 55 39
+ 63 51 39
+ 55 47 35
+ 51 43 35
+252 0 0
+255 255 255
+"""
+
+def load_palette_gpl_text(txt: str):
+    cols=[]
+    for ln in txt.splitlines():
+        s=ln.strip()
+        if not s or s.startswith("#") or re.match(r"^[^\d-]", s): continue
+        m=re.findall(r"(-?\d+)", s)
+        if len(m)>=3:
+            r,g,b = map(int, m[:3])
+            cols.append((max(0,min(255,r)), max(0,min(255,g)), max(0,min(255,b))))
+    if len(cols)<256:
+        cols += [(i,i,i) for i in range(len(cols),256)]
+    return cols[:256]
+
+PALETTE = load_palette_gpl_text(_GPL)
+
+# ---------- FR формат ----------
+def be_u16(b,o): return struct.unpack_from(">H",b,o)[0]
+def be_s16(b,o): return struct.unpack_from(">h",b,o)[0]
+def be_u32(b,o): return struct.unpack_from(">I",b,o)[0]
+
+def parse_fr_bytes(data: bytes):
+    version=be_u32(data,0x00); fps=be_u16(data,0x04); action=be_u16(data,0x06); fpd=be_u16(data,0x08)
+    shiftX=[be_s16(data,0x0A+i*2) for i in range(6)]
+    shiftY=[be_s16(data,0x16+i*2) for i in range(6)]
+    dirOff=[be_u32(data,0x22+i*4) for i in range(6)]
+    base=0x3E
+    dirs=[]; maxW=maxH=0
+    for d in range(6):
+        off=base+dirOff[d]; cur=off; frames=[]
+        for _ in range(fpd):
+            w=be_u16(data,cur); h=be_u16(data,cur+2); sz=be_u32(data,cur+4); xo=be_s16(data,cur+8); yo=be_s16(data,cur+10)
+            raw=data[cur+12:cur+12+sz]
+            if len(raw)<sz: break
+            frames.append({"w":w,"h":h,"xOff":xo,"yOff":yo,"idx":raw})
+            maxW=max(maxW,w); maxH=max(maxH,h)
+            cur+=12+sz
+        dirs.append(frames)
+    return {"header":{"version":version,"fps":fps,"actionFrame":action,"framesPerDir":fpd,"shiftX":shiftX,"shiftY":shiftY,"dirOffsets":dirOff},
+            "directions":dirs,"maxW":maxW,"maxH":maxH}
+
+def frame_to_rgba(fr):
+    w,h = fr["w"], fr["h"]
+    raw = fr["idx"]
+    img = Image.new("RGBA",(w,h),(0,0,0,0))
+    px = img.load(); i=0
+    for y in range(h):
+        for x in range(w):
+            idx = raw[i]; i+=1
+            if idx==0: px[x,y]=(0,0,0,0)
+            else:
+                r,g,b = PALETTE[idx]
+                px[x,y]=(r,g,b,255)
+    return img
+
+# ---------- Классификация ----------
+def classify(path: Path, parsed):
+    pstr = str(path).lower()
+    fname = path.name.lower()
+    dirs  = parsed["directions"]; fpd=parsed["header"]["framesPerDir"]
+    maxW, maxH = parsed["maxW"], parsed["maxH"]
+
+    # явные токены по пути
+    if any(t in pstr for t in ["crit","critter","npc","people","hum"]): kind="critter"
+    elif any(t in pstr for t in ["scen","object","decor","door","tree","wall"]): kind="object"
+    elif any(t in pstr for t in ["item","inv","icon","art"]): kind="item"
+    elif any(t in pstr for t in ["tile","floor"]): kind="tile"
+    elif any(t in pstr for t in ["ui","iface","hud"]): kind="ui"
+    else: kind=None
+
+    # по префиксам имени (часто встречаются)
+    if fname.startswith(("hm","hmc","hmj","hmb","hr")): return ("critter","human_male",["biped"])
+    if fname.startswith(("hf","hfc","hfj","hfb")):      return ("critter","human_female",["biped"])
+    if any(fname.startswith(p) for p in ["dog","dg","mut","scor","rat","ant","gec"]):
+        return ("critter","creature",["quadruped"])
+    if "door" in fname or "gate" in fname: return ("object","door",[])
+    if "tree" in fname or "bush" in fname or "plant" in fname: return ("object","tree",[])
+    if "wall" in fname: return ("object","wall",[])
+    if "inv" in fname or "item" in fname or "icon" in fname: return ("item","item",[])
+
+    # по геометрии
+    many_dirs = sum(1 for d in dirs if d)>=4
+    big = maxW>=50 and maxH>=70
+    if many_dirs and big: return ("critter", kind or "unknown", ["animated"])
+    if maxW<=80 and maxH<=80 and fpd<=10:
+        return ("object", kind or "decor", [])
+    return (kind or "unknown","unknown",[])
+
+# ---------- Основной проход ----------
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", required=True, help="Папка с FR* файлами")
+    ap.add_argument("--out", required=True, help="Папка вывода (будет создана)")
+    ap.add_argument("--export", choices=["frames","spritesheet"], default="frames",
+                    help="Как сохранять: отдельные кадры (frames) или спрайт-листы по направлениям (spritesheet)")
+    ap.add_argument("--gif", action="store_true", help="(опц.) также сделать GIF по первому непустому направлению")
+    ap.add_argument("--fps", type=int, default=10, help="FPS для GIF")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    out  = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    exts = (".frm",".fr0",".fr1",".fr2",".fr3",".fr4",".fr5")
+    files = sorted([p for p in root.rglob("*") if p.suffix.lower() in exts], key=lambda p: p.as_posix())
+
+    asset_map=[]
+    for i,p in enumerate(files,1):
+        data = p.read_bytes()
+        try:
+            parsed = parse_fr_bytes(data)
+        except Exception as e:
+            print(f"[{i}/{len(files)}] {p.name} ERROR: {e}")
+            continue
+
+        kind, category, tags = classify(p, parsed)
+        rel_dir = out / kind / category / p.stem
+        rel_dir.mkdir(parents=True, exist_ok=True)
+
+        # Экспорт
+        first_non_empty = None
+        for d_idx,frames in enumerate(parsed["directions"]):
+            if not frames: continue
+            if first_non_empty is None: first_non_empty = d_idx
+            if args.export=="frames":
+                ddir = rel_dir / f"dir_{d_idx}"
+                ddir.mkdir(exist_ok=True)
+                for f_idx,fr in enumerate(frames):
+                    img = frame_to_rgba(fr)
+                    img.save(ddir / f"frame_{f_idx:02d}.png")
+            else:
+                # spritesheet горизонтальный по направлению
+                h = max(fr["h"] for fr in frames)
+                w_total = sum(fr["w"] for fr in frames)
+                sheet = Image.new("RGBA",(w_total,h),(0,0,0,0))
+                x=0
+                for fr in frames:
+                    im = frame_to_rgba(fr)
+                    sheet.paste(im,(x,h-im.height))
+                    x+=im.width
+                sheet.save(rel_dir / f"spritesheet_dir_{d_idx}.png")
+
+        # (опц.) GIF
+        gif_rel = None
+        if args.gif and first_non_empty is not None:
+            frames = parsed["directions"][first_non_empty]
+            imgs = [frame_to_rgba(fr) for fr in frames]
+            mw = max(im.width for im in imgs); mh = max(im.height for im in imgs)
+            seq=[]
+            for im in imgs:
+                canvas = Image.new("RGBA",(mw,mh),(0,0,0,0))
+                canvas.paste(im,((mw-im.width)//2, mh-im.height))
+                seq.append(canvas.convert("P", palette=Image.ADAPTIVE, colors=256))
+            gif_path = rel_dir / f"preview_dir_{first_non_empty}.gif"
+            seq[0].save(gif_path, save_all=True, append_images=seq[1:], loop=0, duration=max(1,int(1000/args.fps)), disposal=2)
+            gif_rel = str(gif_path.relative_to(out).as_posix())
+
+        # Запись в карту
+        rec = {
+            "id": p.name,
+            "path_in": str(p.relative_to(root).as_posix()),
+            "kind": kind, "category": category, "tags": tags,
+            "out_dir": str(rel_dir.relative_to(out).as_posix()),
+            "dirs": sum(1 for d in parsed["directions"] if d),
+            "framesPerDir": parsed["header"]["framesPerDir"],
+            "fps": parsed["header"]["fps"],
+            "size": {"maxW": parsed["maxW"], "maxH": parsed["maxH"]},
+            "anchorAvg": {
+                "xOff": int(sum((f["xOff"] for d in parsed["directions"] for f in d), 0) / max(1,sum(len(d) for d in parsed["directions"]))),
+                "yOff": int(sum((f["yOff"] for d in parsed["directions"] for f in d), 0) / max(1,sum(len(d) for d in parsed["directions"])))
+            },
+            "previewGif": gif_rel
+        }
+        asset_map.append(rec)
+        print(f"[{i}/{len(files)}] {p.name} -> {kind}/{category}")
+
+    (out/"asset_map.json").write_text(json.dumps(asset_map, ensure_ascii=False, indent=2))
+    print(f"\n✅ Готово. Разложено в: {out}")
+    print(f"   Карта: {out/'asset_map.json'}")
+
+if __name__=="__main__":
+    main()
+
           PY
 
-      - name: Build previews + asset_map.json
+      - name: Extract & sort
         run: |
-          mkdir -p out
-          PAL=$(ls dl/palette* 2>/dev/null | head -n1 || true)
-          if [ -z "$PAL" ]; then
-            # если палитру не дали — создадим «псевдо»-gpl с серой гаммой (чтобы превью не падали)
-            printf "GIMP Palette\n" > dl/fallback.gpl
-            for i in $(seq 0 255); do echo "$i $i $i"; done >> dl/fallback.gpl
-            PAL=dl/fallback.gpl
-          fi
-          python build_asset_map.py --root dl --palette "$PAL" --out out
+          mkdir -p assets_out
+          python fr_extract_and_sort.py --root dl --out assets_out --export '${{ inputs.export_kind }}' $([ '${{ inputs.make_gif }}' = 'true' ] && echo --gif || true)
 
-      - name: Commit asset map + previews to repo
+      - name: Commit assets (PNG) + map
         run: |
-          set -e
-          mkdir -p assets_preview
-          rsync -a out/previews/ assets_preview/ || true
-          cp out/asset_map.json asset_map.json
           git config user.name "github-actions"
           git config user.email "actions@github.com"
-          git add asset_map.json assets_preview || true
-          git commit -m "asset_map + previews (from Drive)" || echo "No changes to commit"
+          rsync -a assets_out/ ./assets/   # положим в папку repo/assets
+          git add assets/asset_map.json || true
+          git add assets/critter assets/object assets/item assets/tile assets/ui || true
+          git commit -m "Add extracted FR assets + asset_map" || echo "No changes"
           git push
 
-      - name: Create/Update release and upload originals
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Upload ORIGINAL FR files to release
+        env: { GH_TOKEN: ${{ github.token }} }
         run: |
-          tag='${{ inputs.release_tag }}'
-          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" -t "$tag" -n "Original FR assets"
-          gh release upload "$tag" dl/** --clobber
+          gh release view '${{ inputs.release_tag }}' >/dev/null 2>&1 || gh release create '${{ inputs.release_tag }}' -t '${{ inputs.release_tag }}' -n 'Original FR assets'
+          gh release upload '${{ inputs.release_tag }}' dl/** --clobber


### PR DESCRIPTION
## Summary
- look for developer-provided hex textures in `/assets` (with `/debug` as a fallback) before falling back to generated materials
- try to load the sample FRM character from `/assets` first and reuse the `/debug` path only if needed, with clearer diagnostics on failure
- stop tracking bundled debug binaries and replace them with an empty placeholder directory for local assets

## Testing
- npm run build --workspace client *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d81a0ec154832c9a8366f8a8d43af5