### PR TITLE
Add JSON map generator UI and asset catalog API

### DIFF
--- a/docs/TASKS.md
+++ b/docs/TASKS.md
@@ -1,52 +1,373 @@
-# Чек-лист задач проекта
+TASKS.md — Браузерная онлайн-игра (веб-порт с нуля)
 
-Этот документ фиксирует обязательные результаты для MVP веб-ремейка Fallout, разбитые на отдельные pull request'ы,
-чтобы работа шла поэтапно при всегда зелёном CI.
+Правила для Codex:
 
-## Структура репозитория
-- [x] Настроить npm workspaces с пакетами `server`, `client`, `shared` и `tools`.
-- [x] Добавить строгие конфиги TypeScript, ESLint, Prettier и общие правила `.gitignore`.
-- [ ] Подготовить конфиг Render (`render.yaml`) и GitHub Actions для CI и импорта карт.
-- [x] Заполнить `packages/server/.env.example` всеми необходимыми переменными окружения.
+Прочитай TASKS.md. 2) Выполни только первый невыполненный шаг. 3) Проверь «Done when». 4) Если не выполнено — заполни STATE.last_error и остановись без коммита. 5) Если выполнено — один коммит по шаблону, отметь чекбокс, обнови STATE, остановись.
 
-## Тулы: импорт карт и ассетов
-- [x] Реализовать парсер `.fomap` (`packages/tools/fomap-import.ts`), возвращающий структурированные данные карты.
-- [x] Реализовать резолвер PID прототипов (`packages/tools/proto-resolve.ts`).
-- [x] Собрать CLI-импортёр (`packages/tools/import-map.ts`), который пишет `assets/maps/<mapId>.json`.
-- [x] Добавить утилиту `import-all` и npm-скрипты для пакетной генерации карт.
-- [ ] Написать модульные тесты для инструментов импорта.
+STATE
 
-## Клиент: рантайм-декодирование FR/FRM
-- [ ] Добавить модуль с канонической палитрой Fallout.
-- [ ] Реализовать декодер FRM, возвращающий кэшируемые атласы с канвасами для каждого кадра.
-- [ ] Настроить цепочку загрузки ассетов (сначала `.png|.gif`, затем `.frm|fr?`).
-- [ ] Покрыть крайние случаи декодера модульными тестами.
+last_completed_step: none
 
-## Серверная платформа
-- [x] Подключить HTTP-сервер на Express со статикой и маршрутом `/art/**`, читающим оригинальные ассеты при отсутствии предконверта.
-- [ ] Открыть REST-эндпоинты для здоровья, списка карт и деталей карты.
-- [ ] Реализовать аутентификацию (register, login, refresh, logout, me) на Prisma, bcrypt, JWT, с refresh-cookie, rate limiting и проверкой через Zod.
-- [ ] Настроить WebSocket `/ws` со специфицированным протоколом и состоянием мира в памяти.
-- [ ] Вынести общие сетевые типы в `packages/shared/net.ts`.
-- [ ] Добавить кэш загрузчика карт и вспомогательные функции гекс-координат с тестами.
+next_step_hint: TASK-000
 
-## Клиентский игровой цикл
-- [ ] Инициализировать приложение Vite + PixiJS с полноэкранным рендером гекс-карты, слоями и Z-сортировкой.
-- [ ] Получать данные карты и рисовать ground, roof, объекты и игроков.
-- [ ] Реализовать анимации персонажа на FRM (idle/walk, 6 направлений).
-- [ ] Добавить обработку ввода для перемещения, поворота, чата и мобильного полноэкранного режима.
-- [ ] Подключить WebSocket-клиент к протоколу: отправка/приём, интерполяция, оверлей пинга.
-- [ ] Добавить минимальный UI для аутентификации и выбора карты.
+last_error:
 
-## Деплой и контроль качества
-- [ ] Добиться успешного выполнения `npm run lint`, `npm run typecheck` и `npm run build` локально и в CI.
-- [ ] Задокументировать команды `npm run dev` и тестовый процесс в `README.md`.
-- [ ] Подготовить команду запуска для Render и убедиться, что `/healthz` отвечает 200.
-- [ ] Создать опциональный workflow конвертации FR→PNG/GIF (`packages/tools/fr2gif.ts`).
+Цели проекта
 
-## Дорожная карта после MVP (для справки)
-- [ ] Поиск пути (A*) с учётом занятых гексов.
-- [ ] Разделение на инстансы карт и сохранение состояния мира.
-- [ ] Боевая система, инвентарь и сценарные взаимодействия.
-- [ ] Спрайтовые атласы, батчинг и оптимизации кэширования кадров FRM.
-- [ ] Дополнительный провайдер авторизации через Telegram Mini App.
+Веб-клиент (TypeScript + Vite + PixiJS/Phaser) с изометрическим/топ-даун 2D-рендером, UI, управлением.
+
+Онлайн-синхронизация через WebSocket (Node.js + ws/Express), авторитарный сервер для честной симуляции.
+
+Ядро механик: карта (тайлсет/слои), спавны, лут/инвентарь, статы персонажа, стрельба/урон/броня, простейший ИИ, триггеры и зоны (safe/quest), чат.
+
+Минимальная персистентность (SQLite/Prisma): аккаунт/профиль, базовые прогрессы.
+
+Инструменты: конвертация ассетов (FR→GIF/PNG + meta.json; при необходимости FOMAP→map.json), JSON-схемы данных.
+
+Технологии (зафиксировано)
+
+Client: TypeScript, Vite, PixiJS (или Phaser — см. TASK-012), Zustand (состояние), Zod (валидация), Playwright (smoke E2E).
+
+Server: Node 20+, Express, ws, Prisma (SQLite dev → Postgres prod).
+
+Статика: /assets/** — единственный источник ассетов.
+
+Архитектура: модульная, ECS-лайт (Entity + компоненты), авторитарный сервер, клиент — предикт/интерполяция.
+
+ФАЗА A — Чистый старт и каркас
+TASK-000: Чистый старт репозитория
+
+Действия
+
+Создать ветку chore/web-online-boot.
+
+Оставить в корне: /assets/**, README.md, .gitignore, LICENSE (если есть), TASKS.md. Всё остальное удалить через git rm -r.
+Done when
+
+В репо только перечисленное.
+Коммит
+
+chore(repo): clean start keeping only /assets and docs — Refs: TASK-000
+
+TASK-001: Bootstrap клиента
+
+Действия
+
+Создать Client/ (Vite + TS), страницу / с заглушкой «Online build ok».
+
+В vite.config.ts добавить алиас @assets → /assets.
+
+Скрипты в корне: dev:client, build:client.
+Done when
+
+pnpm dev:client поднимает страницу, импорт из @assets работает.
+Коммит
+
+feat(client): bootstrap Vite+TS with @assets alias — Refs: TASK-001
+
+TASK-002: Bootstrap сервера
+
+Действия
+
+Создать Server/ (Node+Express+ws), /healthz → ok, WS /ws отдает echo.
+
+Скрипты в корне: dev:server, dev (параллельно клиент+сервер).
+Done when
+
+curl /healthz ok, WS echo отвечает.
+Коммит
+
+feat(server): bootstrap express+ws with healthz/echo — Refs: TASK-002
+
+ФАЗА B — Спеки и конвертация ассетов
+TASK-010: JSON-схемы данных (v1)
+
+Действия
+
+Client/spec/map.schema.json: meta, grid, tilesets, layers, objects, triggers, spawn, collisions.
+
+Client/spec/sprite.schema.json: анимации (кадры, направления, длительности).
+
+Примеры в assets/examples/**.
+Done when
+
+Примеры валидируются Zod/AJV в отдельном скрипте.
+Коммит
+
+feat(spec): add map & sprite schemas v1 with examples — Refs: TASK-010
+
+TASK-011: Конвертер FR → GIF/PNG (+meta.json)
+
+Действия
+
+scripts/convert-fr-to-gif.mjs: на вход FR-файлы из /assets/**, на выход спрайт-листы (GIF/PNG) + meta.json по sprite.schema.json в assets/sprites/<entity>/**.
+Done when
+
+На 2–3 примерах конверсия успешна, мета читается клиентом.
+Коммит
+
+feat(tooling): FR→GIF/PNG converter with sprite meta — Refs: TASK-011
+
+TASK-012: (Опция) Переключатель PixiJS↔Phaser
+
+Действия
+
+Подготовить минимальный абстрактный слой рендера с одним Renderer интерфейсом и двумя имплементациями (Pixi/Phaser), выбор через env.
+Done when
+
+Стартовая сцена рендерится в обоих режимах.
+Коммит
+
+chore(render): add renderer abstraction (pixi|phaser) — Refs: TASK-012
+
+ФАЗА C — Клиентский движок
+TASK-020: Игровой цикл и сцены
+
+Действия
+
+Client/src/engine/core/{loop,scene}.ts: fixed update 60fps, delta, пауза, менеджер сцен.
+Done when
+
+Переключение boot → loading → gameplay.
+Коммит
+
+feat(engine): loop and scene manager — Refs: TASK-020
+
+TASK-021: Загрузчик ресурсов
+
+Действия
+
+Унифицированный лоадер json/images/audio, прогресс-бар. Регистрация ассетов из /assets.
+Done when
+
+Ассеты карт и спрайтов грузятся через единый API.
+Коммит
+
+feat(engine): resource loader with progress — Refs: TASK-021
+
+TASK-022: Рендер карты (изо/топ-даун)
+
+Действия
+
+engine/map/tilemap.ts: слои, порядки, оффсеты; камера (pan/zoom), границы, выбор клетки.
+Done when
+
+Карта-пример рендерится стабильно.
+Коммит
+
+feat(map): tile renderer with camera & hover — Refs: TASK-022
+
+TASK-023: Коллизии и A*
+
+Действия
+
+Маска коллизий по слою; A* по grid; клик-to-move.
+Done when
+
+Персонаж строит и проходит маршрут по клику.
+Коммит
+
+feat(nav): grid collisions and pathfinding — Refs: TASK-023
+
+TASK-024: Сущности и анимации
+
+Действия
+
+База Entity + компоненты: Transform, SpriteAnim (читает meta.json), Stats(HP/Armor).
+Done when
+
+Игрок анимируется в idle/walk с направлениями.
+Коммит
+
+feat(entities): base entity & sprite animation — Refs: TASK-024
+
+TASK-025: Инвентарь и лут
+
+Действия
+
+Модель предмета, слоты, drag&drop UI, экипировка (модификаторы статов).
+Done when
+
+DnD работает, статы меняются от экипировки.
+Коммит
+
+feat(inventory): items, slots, drag-and-drop — Refs: TASK-025
+
+TASK-026: Бой (минимум)
+
+Действия
+
+Луч/пули, урон, КД, точность, броня; визуальные эффекты (muzzle/hit, хп-бар).
+Done when
+
+Игрок наносит урон манекену; КД и броня учитываются.
+Коммит
+
+feat(combat): realtime-lite combat loop — Refs: TASK-026
+
+ФАЗА D — Сеть и серверная логика
+TASK-030: Протокол WS (v0)
+
+Действия
+
+Определить типы сообщений: join, state, input, hit, loot, chat.
+
+Клиент: предикт ввода, интерполяция; Сервер: авторитарная позиция/урон.
+Done when
+
+Два клиента в одной комнате видят друг друга корректно.
+Коммит
+
+feat(net): ws protocol v0 (authoritative server) — Refs: TASK-030
+
+TASK-031: Синхронизация состояния
+
+Действия
+
+Серверные тики (20–30 т/с), снапшоты, delta-компрессия (простая).
+Done when
+
+Стабильная позиционная синхронизация без «телепортов».
+Коммит
+
+feat(net): snapshot sync & client interpolation — Refs: TASK-031
+
+TASK-032: Спавны, зоны, триггеры
+
+Действия
+
+Серверные зоны (safe/PvP), триггеры enter/leave; спавн-поинты.
+Done when
+
+Вход/выход из зоны меняет правила урона/агрессии.
+Коммит
+
+feat(server): zones and triggers — Refs: TASK-032
+
+TASK-033: Персистентность (минимум)
+
+Действия
+
+Prisma + SQLite: таблицы users, profiles. Эндпоинт гостевого входа.
+Done when
+
+Профиль создаётся и читается, базовые поля сохраняются.
+Коммит
+
+feat(db): prisma sqlite bootstrap (users/profiles) — Refs: TASK-033
+
+ФАЗА E — UI/UX и мета
+TASK-040: HUD и инвентарь-UI
+
+Действия
+
+HP/Armor/Ammo, мини-карта, горячие слоты, чат, лог событий.
+Done when
+
+Все элементы обновляются в реальном времени.
+Коммит
+
+feat(ui): hud, hotbar, chat, event log — Refs: TASK-040
+
+TASK-041: Меню и настройка управления
+
+Действия
+
+Ремап клавиш/сенсорных жестов; чувствительность; режимы камеры.
+Done when
+
+Настройки сохраняются в localStorage, применяются без перезапуска.
+Коммит
+
+feat(ui): settings (bindings/sensitivity) — Refs: TASK-041
+
+ФАЗА F — E2E, деплой, защита от очевидного читерства
+TASK-050: E2E-smoke (Playwright)
+
+Действия
+
+Тест: два клиента подключаются, перемещаются, видят состояние.
+Done when
+
+Тест зелёный в CI.
+Коммит
+
+test(e2e): two-clients movement & visibility — Refs: TASK-050
+
+TASK-051: Деплой превью
+
+Действия
+
+Client → Vercel/Netlify, Server → Render/Fly.io; env-vars; CORS/WS.
+Done when
+
+Публичные URLs для клиента и сервера, игра запускается.
+Коммит
+
+chore(deploy): preview hosting for client/server — Refs: TASK-051
+
+TASK-052: Базовая защита
+
+Действия
+
+Сервер валидирует вход (скорость, через стены, урон вне зоны); простая rate-limit по IP/сессии.
+Done when
+
+Нелегитимные действия отклоняются сервером.
+Коммит
+
+feat(anticheat): sanity checks and rate limits — Refs: TASK-052
+
+Чеклист (Codex отмечает)
+
+ TASK-000 — clean start
+
+ TASK-001 — client bootstrap
+
+ TASK-002 — server bootstrap
+
+ TASK-010 — schemas v1
+
+ TASK-011 — FR→GIF/PNG converter
+
+ TASK-012 — renderer abstraction (opt)
+
+ TASK-020 — loop & scenes
+
+ TASK-021 — resource loader
+
+ TASK-022 — tile renderer
+
+ TASK-023 — collisions & A*
+
+ TASK-024 — entities & anim
+
+ TASK-025 — inventory
+
+ TASK-026 — combat
+
+ TASK-030 — ws protocol v0
+
+ TASK-031 — snapshot sync
+
+ TASK-032 — zones & triggers
+
+ TASK-033 — persistence
+
+ TASK-040 — HUD & UI
+
+ TASK-041 — settings
+
+ TASK-050 — e2e smoke
+
+ TASK-051 — deploy
+
+ TASK-052 — anticheat sanity
+
+Примечания
+
+Если ассеты в экзотических форматах — сначала добавь/запусти конвертеры (TASK-011 и при необходимости FOMAP→JSON, можно вставить как TASK-013).
+
+Сервер всегда «истина»: клиент лишь предсказывает и интерполирует.
+
+Любая ошибка в шаге — сразу STATE.last_error и остановка без коммита.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1077,10 +1077,6 @@
       "resolved": "packages/client",
       "link": true
     },
-    "node_modules/@tla/server": {
-      "resolved": "packages/server",
-      "link": true
-    },
     "node_modules/@tla/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -4589,6 +4585,10 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/server": {
+      "resolved": "packages/server",
+      "link": true
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -5795,7 +5795,6 @@
       }
     },
     "packages/server": {
-      "name": "@tla/server",
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^5.13.0",

--- a/packages/client/src/generator.ts
+++ b/packages/client/src/generator.ts
@@ -1,0 +1,858 @@
+import { drawMap, getPixelMetrics, projectHex } from './rendering';
+import type {
+  AssetDescriptor,
+  HexGridInfo,
+  ImageCache,
+  MapData,
+  MapObject,
+  MapTile,
+} from './types';
+
+interface GeneratorPage {
+  root: HTMLElement;
+  activate(): void;
+  deactivate(): void;
+}
+
+interface AssetCatalogEntry {
+  id: string;
+  folder: string;
+  name: string;
+  originalPath: string;
+  dirs: number;
+  framesPerDir: number;
+  descriptor: AssetDescriptor;
+}
+
+type PlacementMode = 'ground' | 'roof' | 'object' | 'erase';
+
+interface EditableMapState {
+  id: string;
+  name: string;
+  hex: HexGridInfo;
+  size: { w: number; h: number };
+  tiles: Map<string, MapTile>;
+  objects: Map<string, MapObject[]>;
+}
+
+interface RenderContext {
+  offsetX: number;
+  offsetY: number;
+  dpr: number;
+}
+
+const TILE_FOLDERS = new Set(['tiles']);
+const OBJECT_FOLDERS = new Set(['misc', 'scenery', 'skilldex', 'splash', 'walls']);
+
+export function createGeneratorPage(): GeneratorPage {
+  const root = document.createElement('div');
+  root.className = 'generator-page';
+
+  const sidebar = document.createElement('aside');
+  sidebar.className = 'generator-sidebar';
+
+  const settingsSection = document.createElement('section');
+  settingsSection.className = 'generator-section';
+
+  const settingsHeader = document.createElement('h2');
+  settingsHeader.textContent = 'Параметры карты';
+  settingsSection.appendChild(settingsHeader);
+
+  const settingsForm = document.createElement('form');
+  settingsForm.className = 'generator-form';
+  settingsSection.appendChild(settingsForm);
+
+  sidebar.appendChild(settingsSection);
+
+  const paletteSection = document.createElement('section');
+  paletteSection.className = 'generator-section';
+
+  const paletteHeader = document.createElement('h2');
+  paletteHeader.textContent = 'Библиотека ассетов';
+  paletteSection.appendChild(paletteHeader);
+
+  const paletteSearch = document.createElement('input');
+  paletteSearch.type = 'search';
+  paletteSearch.placeholder = 'Поиск по имени или пути…';
+  paletteSearch.className = 'asset-search';
+  paletteSection.appendChild(paletteSearch);
+
+  const paletteList = document.createElement('div');
+  paletteList.className = 'asset-list';
+  paletteSection.appendChild(paletteList);
+
+  sidebar.appendChild(paletteSection);
+
+  const content = document.createElement('div');
+  content.className = 'generator-content';
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'generator-toolbar';
+
+  const modeLabel = document.createElement('span');
+  modeLabel.textContent = 'Режим:';
+  toolbar.appendChild(modeLabel);
+
+  const modeButtons: { mode: PlacementMode; button: HTMLButtonElement }[] = [];
+  const modes: { label: string; mode: PlacementMode }[] = [
+    { label: 'Пол', mode: 'ground' },
+    { label: 'Крыша', mode: 'roof' },
+    { label: 'Объект', mode: 'object' },
+    { label: 'Ластик', mode: 'erase' },
+  ];
+  for (const entry of modes) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = entry.label;
+    button.className = 'mode-button';
+    toolbar.appendChild(button);
+    modeButtons.push({ mode: entry.mode, button });
+  }
+
+  const selectionInfo = document.createElement('div');
+  selectionInfo.className = 'selection-info';
+  toolbar.appendChild(selectionInfo);
+
+  const objectControls = document.createElement('div');
+  objectControls.className = 'object-controls';
+  const dirLabel = document.createElement('label');
+  dirLabel.textContent = 'Направление:';
+  const dirInput = document.createElement('input');
+  dirInput.type = 'number';
+  dirInput.min = '0';
+  dirInput.max = '5';
+  dirInput.value = '0';
+  dirInput.step = '1';
+  dirLabel.appendChild(dirInput);
+
+  const elevLabel = document.createElement('label');
+  elevLabel.textContent = 'Высота:';
+  const elevInput = document.createElement('input');
+  elevInput.type = 'number';
+  elevInput.value = '0';
+  elevInput.step = '1';
+  elevLabel.appendChild(elevInput);
+
+  objectControls.append(dirLabel, elevLabel);
+  toolbar.appendChild(objectControls);
+
+  const canvasWrap = document.createElement('div');
+  canvasWrap.className = 'generator-canvas-wrap';
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'generator-canvas';
+  canvasWrap.appendChild(canvas);
+
+  const generatorStatus = document.createElement('div');
+  generatorStatus.className = 'generator-status';
+
+  const summary = document.createElement('div');
+  summary.className = 'generator-summary';
+
+  const exportSection = document.createElement('section');
+  exportSection.className = 'generator-section export-section';
+  const exportHeader = document.createElement('h2');
+  exportHeader.textContent = 'Экспорт карты';
+  exportSection.appendChild(exportHeader);
+
+  const exportButtons = document.createElement('div');
+  exportButtons.className = 'export-actions';
+
+  const exportButton = document.createElement('button');
+  exportButton.type = 'button';
+  exportButton.textContent = 'Сформировать JSON';
+  exportButtons.appendChild(exportButton);
+
+  const downloadButton = document.createElement('button');
+  downloadButton.type = 'button';
+  downloadButton.textContent = 'Скачать файл';
+  exportButtons.appendChild(downloadButton);
+
+  const copyButton = document.createElement('button');
+  copyButton.type = 'button';
+  copyButton.textContent = 'Копировать';
+  exportButtons.appendChild(copyButton);
+
+  exportSection.appendChild(exportButtons);
+
+  const exportOutput = document.createElement('textarea');
+  exportOutput.readOnly = true;
+  exportOutput.className = 'export-output';
+  exportSection.appendChild(exportOutput);
+
+  content.append(toolbar, canvasWrap, generatorStatus, summary, exportSection);
+
+  root.append(sidebar, content);
+
+  let assets: AssetCatalogEntry[] = [];
+  const assetLookup = new Map<string, AssetCatalogEntry>();
+  let placementMode: PlacementMode = 'ground';
+  let selectedAsset: AssetCatalogEntry | null = null;
+  let hoverCell: { q: number; r: number } | null = null;
+  let renderContext: RenderContext | null = null;
+  const imageCache: ImageCache = new Map();
+  let assetsLoaded = false;
+
+  const mapState: EditableMapState = {
+    id: 'custom-map',
+    name: 'Новая карта',
+    hex: {
+      orientation: 'isometric',
+      size: 28,
+      pixel: { tileWidth: 80, tileHeight: 36, elevation: 96 },
+    },
+    size: { w: 16, h: 16 },
+    tiles: new Map(),
+    objects: new Map(),
+  };
+
+  function updateModeButtons(): void {
+    for (const entry of modeButtons) {
+      if (entry.mode === placementMode) {
+        entry.button.classList.add('active');
+      } else {
+        entry.button.classList.remove('active');
+      }
+    }
+    objectControls.style.display = placementMode === 'object' ? 'flex' : 'none';
+  }
+
+  function updateSelectionInfo(): void {
+    if (!selectedAsset) {
+      selectionInfo.textContent = 'Ассет не выбран';
+      return;
+    }
+    selectionInfo.textContent = `${selectedAsset.folder} / ${selectedAsset.name}`;
+  }
+
+  function updateSummary(): void {
+    const tileCount = mapState.tiles.size;
+    let objectCount = 0;
+    for (const list of mapState.objects.values()) {
+      objectCount += list.length;
+    }
+    summary.textContent = `Размер: ${mapState.size.w} × ${mapState.size.h} • Плиток: ${tileCount} • Объектов: ${objectCount}`;
+  }
+
+  function setStatus(message: string, isError = false): void {
+    generatorStatus.textContent = message;
+    generatorStatus.classList.toggle('error', isError);
+  }
+
+  function tileKey(layer: 'ground' | 'roof', q: number, r: number): string {
+    return `${layer}:${q}:${r}`;
+  }
+
+  function objectKey(q: number, r: number): string {
+    return `${q}:${r}`;
+  }
+
+  function ensureWithinBounds(q: number, r: number): boolean {
+    return q >= 0 && r >= 0 && q < mapState.size.w && r < mapState.size.h;
+  }
+
+  function addTile(layer: 'ground' | 'roof', q: number, r: number, art: string): void {
+    if (!ensureWithinBounds(q, r)) {
+      return;
+    }
+    const key = tileKey(layer, q, r);
+    mapState.tiles.set(key, { q, r, layer, art });
+  }
+
+  function removeTile(q: number, r: number, layer?: 'ground' | 'roof'): void {
+    if (layer) {
+      mapState.tiles.delete(tileKey(layer, q, r));
+      return;
+    }
+    mapState.tiles.delete(tileKey('ground', q, r));
+    mapState.tiles.delete(tileKey('roof', q, r));
+  }
+
+  function addObject(q: number, r: number, art: string, dir: number, elev: number): void {
+    if (!ensureWithinBounds(q, r)) {
+      return;
+    }
+    const key = objectKey(q, r);
+    const list = mapState.objects.get(key) ?? [];
+    const id = globalThis.crypto?.randomUUID
+      ? globalThis.crypto.randomUUID()
+      : `obj-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    list.push({ id, q, r, art, dir, elev });
+    mapState.objects.set(key, list);
+  }
+
+  function removeObjects(q: number, r: number): void {
+    mapState.objects.delete(objectKey(q, r));
+  }
+
+  function clearOutsideBounds(): void {
+    for (const key of [...mapState.tiles.keys()]) {
+      const [, qStr, rStr] = key.split(':');
+      const q = Number.parseInt(qStr, 10);
+      const r = Number.parseInt(rStr, 10);
+      if (!ensureWithinBounds(q, r)) {
+        mapState.tiles.delete(key);
+      }
+    }
+    for (const [key] of mapState.objects.entries()) {
+      const [qStr, rStr] = key.split(':');
+      const q = Number.parseInt(qStr, 10);
+      const r = Number.parseInt(rStr, 10);
+      if (!ensureWithinBounds(q, r)) {
+        mapState.objects.delete(key);
+      }
+    }
+  }
+
+  function buildMapData(): MapData {
+    const tiles = [...mapState.tiles.values()].sort((a, b) => {
+      if (a.layer === b.layer) {
+        if (a.r === b.r) {
+          return a.q - b.q;
+        }
+        return a.r - b.r;
+      }
+      return a.layer.localeCompare(b.layer);
+    });
+
+    const objects: MapObject[] = [];
+    for (const list of mapState.objects.values()) {
+      for (const obj of list) {
+        objects.push({ ...obj });
+      }
+    }
+
+    const assetsMeta: Record<string, AssetDescriptor> = {};
+    for (const tile of tiles) {
+      const asset = assetLookup.get(tile.art);
+      if (asset) {
+        assetsMeta[tile.art] = asset.descriptor;
+      }
+    }
+    for (const object of objects) {
+      const asset = assetLookup.get(object.art);
+      if (asset) {
+        assetsMeta[object.art] = asset.descriptor;
+      }
+    }
+
+    return {
+      id: mapState.id,
+      name: mapState.name,
+      hex: { ...mapState.hex },
+      size: { ...mapState.size },
+      tiles,
+      objects,
+      assets: assetsMeta,
+    };
+  }
+
+  async function refreshPreview(): Promise<void> {
+    const mapData = buildMapData();
+    try {
+      const result = await drawMap(canvas, mapData, imageCache);
+      renderContext = { offsetX: result.offsetX, offsetY: result.offsetY, dpr: result.dpr };
+      drawGridOverlay(result.ctx, result.offsetX, result.offsetY, mapData);
+      setStatus('Готово');
+    } catch (error) {
+      console.error(error);
+      setStatus('Не удалось отрисовать карту', true);
+    }
+  }
+
+  function drawGridOverlay(
+    ctx: CanvasRenderingContext2D,
+    offsetX: number,
+    offsetY: number,
+    map: MapData,
+  ): void {
+    ctx.save();
+    ctx.lineWidth = 1;
+    ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+    ctx.fillStyle = 'rgba(255,255,255,0.05)';
+
+    for (let r = 0; r < map.size.h; r += 1) {
+      for (let q = 0; q < map.size.w; q += 1) {
+        const polygon = computeCellPolygon(q, r, map.hex);
+        if (polygon.length === 0) {
+          continue;
+        }
+        ctx.beginPath();
+        ctx.moveTo(polygon[0].x + offsetX, polygon[0].y + offsetY);
+        for (let i = 1; i < polygon.length; i += 1) {
+          ctx.lineTo(polygon[i].x + offsetX, polygon[i].y + offsetY);
+        }
+        ctx.closePath();
+        if (hoverCell && hoverCell.q === q && hoverCell.r === r) {
+          ctx.fillStyle = 'rgba(255,255,255,0.1)';
+          ctx.fill();
+          ctx.fillStyle = 'rgba(255,255,255,0.05)';
+        }
+        ctx.stroke();
+      }
+    }
+
+    ctx.restore();
+  }
+
+  function computeCellPolygon(q: number, r: number, hex: HexGridInfo): { x: number; y: number }[] {
+    const points: { x: number; y: number }[] = [];
+    if (hex.orientation === 'isometric') {
+      const metrics = getPixelMetrics(hex);
+      const base = projectHex(q, r, hex);
+      const halfWidth = metrics.tileWidth / 2;
+      const halfHeight = metrics.tileHeight / 2;
+      const centerY = base.y - halfHeight;
+      points.push(
+        { x: base.x, y: centerY - halfHeight },
+        { x: base.x + halfWidth, y: centerY },
+        { x: base.x, y: base.y },
+        { x: base.x - halfWidth, y: centerY },
+      );
+      return points;
+    }
+
+    const center = projectHex(q, r, hex);
+    const radius = Math.max(1, hex.size);
+    const angleOffset = hex.orientation === 'pointy' ? -30 : 0;
+    for (let i = 0; i < 6; i += 1) {
+      const angle = ((60 * i + angleOffset) * Math.PI) / 180;
+      points.push({ x: center.x + radius * Math.cos(angle), y: center.y + radius * Math.sin(angle) });
+    }
+    return points;
+  }
+
+  function pointInPolygon(point: { x: number; y: number }, polygon: { x: number; y: number }[]): boolean {
+    let inside = false;
+    for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i, i += 1) {
+      const xi = polygon[i].x;
+      const yi = polygon[i].y;
+      const xj = polygon[j].x;
+      const yj = polygon[j].y;
+      const intersect = yi > point.y !== yj > point.y && point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+      if (intersect) {
+        inside = !inside;
+      }
+    }
+    return inside;
+  }
+
+  function pickCell(worldX: number, worldY: number): { q: number; r: number } | null {
+    const hex = mapState.hex;
+    for (let r = 0; r < mapState.size.h; r += 1) {
+      for (let q = 0; q < mapState.size.w; q += 1) {
+        const polygon = computeCellPolygon(q, r, hex);
+        if (polygon.length === 0) {
+          continue;
+        }
+        if (pointInPolygon({ x: worldX, y: worldY }, polygon)) {
+          return { q, r };
+        }
+      }
+    }
+    return null;
+  }
+
+  function handleCanvasAction(event: MouseEvent): void {
+    if (!renderContext) {
+      return;
+    }
+    const rect = canvas.getBoundingClientRect();
+    const cssX = event.clientX - rect.left;
+    const cssY = event.clientY - rect.top;
+    const worldX = cssX - renderContext.offsetX;
+    const worldY = cssY - renderContext.offsetY;
+    const cell = pickCell(worldX, worldY);
+    if (!cell) {
+      return;
+    }
+
+    if (placementMode === 'erase') {
+      removeTile(cell.q, cell.r);
+      removeObjects(cell.q, cell.r);
+      updateSummary();
+      void refreshPreview();
+      return;
+    }
+
+    if (!selectedAsset) {
+      setStatus('Сначала выберите ассет', true);
+      return;
+    }
+
+    if (placementMode === 'ground' || placementMode === 'roof') {
+      if (!TILE_FOLDERS.has(selectedAsset.folder)) {
+        setStatus('Для плиток выберите ассет из папки tiles', true);
+        return;
+      }
+      addTile(placementMode, cell.q, cell.r, selectedAsset.id);
+    } else if (placementMode === 'object') {
+      if (!OBJECT_FOLDERS.has(selectedAsset.folder) && !TILE_FOLDERS.has(selectedAsset.folder)) {
+        setStatus('Ассет не подходит для объектов', true);
+        return;
+      }
+      const dir = Number.parseInt(dirInput.value, 10) || 0;
+      const elev = Number.parseInt(elevInput.value, 10) || 0;
+      addObject(cell.q, cell.r, selectedAsset.id, dir, elev);
+    }
+
+    updateSummary();
+    void refreshPreview();
+  }
+
+  function updateHover(event: MouseEvent): void {
+    if (!renderContext) {
+      return;
+    }
+    const rect = canvas.getBoundingClientRect();
+    const cssX = event.clientX - rect.left;
+    const cssY = event.clientY - rect.top;
+    const worldX = cssX - renderContext.offsetX;
+    const worldY = cssY - renderContext.offsetY;
+    const cell = pickCell(worldX, worldY);
+    const changed = (hoverCell?.q ?? -1) !== (cell?.q ?? -1) || (hoverCell?.r ?? -1) !== (cell?.r ?? -1);
+    hoverCell = cell;
+    if (changed) {
+      void refreshPreview();
+    }
+  }
+
+  function clearHover(): void {
+    if (hoverCell) {
+      hoverCell = null;
+      void refreshPreview();
+    }
+  }
+
+  canvas.addEventListener('click', handleCanvasAction);
+  canvas.addEventListener('mousemove', updateHover);
+  canvas.addEventListener('mouseleave', clearHover);
+
+  for (const entry of modeButtons) {
+    entry.button.addEventListener('click', () => {
+      placementMode = entry.mode;
+      updateModeButtons();
+    });
+  }
+
+  function createLabeledInput(
+    labelText: string,
+    input: HTMLInputElement | HTMLSelectElement,
+    description?: string,
+  ): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'form-field';
+    const label = document.createElement('label');
+    label.textContent = labelText;
+    label.appendChild(input);
+    wrapper.appendChild(label);
+    if (description) {
+      const hint = document.createElement('span');
+      hint.className = 'field-hint';
+      hint.textContent = description;
+      wrapper.appendChild(hint);
+    }
+    return wrapper;
+  }
+
+  const idInput = document.createElement('input');
+  idInput.type = 'text';
+  idInput.value = mapState.id;
+  settingsForm.appendChild(createLabeledInput('Идентификатор', idInput));
+
+  idInput.addEventListener('input', () => {
+    mapState.id = idInput.value.trim() || 'custom-map';
+  });
+
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.value = mapState.name;
+  settingsForm.appendChild(createLabeledInput('Название', nameInput));
+
+  nameInput.addEventListener('input', () => {
+    mapState.name = nameInput.value.trim() || 'Новая карта';
+  });
+
+  const widthInput = document.createElement('input');
+  widthInput.type = 'number';
+  widthInput.min = '1';
+  widthInput.value = mapState.size.w.toString();
+  settingsForm.appendChild(createLabeledInput('Ширина', widthInput));
+
+  widthInput.addEventListener('change', () => {
+    const value = Number.parseInt(widthInput.value, 10);
+    if (Number.isFinite(value) && value > 0) {
+      mapState.size.w = value;
+      clearOutsideBounds();
+      updateSummary();
+      void refreshPreview();
+    }
+  });
+
+  const heightInput = document.createElement('input');
+  heightInput.type = 'number';
+  heightInput.min = '1';
+  heightInput.value = mapState.size.h.toString();
+  settingsForm.appendChild(createLabeledInput('Высота', heightInput));
+
+  heightInput.addEventListener('change', () => {
+    const value = Number.parseInt(heightInput.value, 10);
+    if (Number.isFinite(value) && value > 0) {
+      mapState.size.h = value;
+      clearOutsideBounds();
+      updateSummary();
+      void refreshPreview();
+    }
+  });
+
+  const orientationSelect = document.createElement('select');
+  for (const value of ['isometric', 'pointy', 'flat'] as const) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    orientationSelect.appendChild(option);
+  }
+  orientationSelect.value = mapState.hex.orientation;
+  settingsForm.appendChild(createLabeledInput('Ориентация гекса', orientationSelect));
+
+  orientationSelect.addEventListener('change', () => {
+    const value = orientationSelect.value as HexGridInfo['orientation'];
+    mapState.hex.orientation = value;
+    if (value === 'isometric') {
+      mapState.hex.pixel = mapState.hex.pixel ?? { tileWidth: 80, tileHeight: 36, elevation: 96 };
+      pixelWidthInput.value = `${mapState.hex.pixel.tileWidth}`;
+      pixelHeightInput.value = `${mapState.hex.pixel.tileHeight}`;
+      pixelElevationInput.value = `${mapState.hex.pixel.elevation}`;
+    } else {
+      delete mapState.hex.pixel;
+    }
+    void refreshPreview();
+  });
+
+  const sizeInput = document.createElement('input');
+  sizeInput.type = 'number';
+  sizeInput.min = '1';
+  sizeInput.value = mapState.hex.size.toString();
+  settingsForm.appendChild(createLabeledInput('Размер гекса', sizeInput));
+
+  sizeInput.addEventListener('change', () => {
+    const value = Number.parseInt(sizeInput.value, 10);
+    if (Number.isFinite(value) && value > 0) {
+      mapState.hex.size = value;
+      void refreshPreview();
+    }
+  });
+
+  const pixelWidthInput = document.createElement('input');
+  pixelWidthInput.type = 'number';
+  pixelWidthInput.min = '1';
+  pixelWidthInput.value = mapState.hex.pixel?.tileWidth?.toString() ?? '80';
+
+  const pixelHeightInput = document.createElement('input');
+  pixelHeightInput.type = 'number';
+  pixelHeightInput.min = '1';
+  pixelHeightInput.value = mapState.hex.pixel?.tileHeight?.toString() ?? '36';
+
+  const pixelElevationInput = document.createElement('input');
+  pixelElevationInput.type = 'number';
+  pixelElevationInput.min = '0';
+  pixelElevationInput.value = mapState.hex.pixel?.elevation?.toString() ?? '96';
+
+  const pixelWrapper = document.createElement('div');
+  pixelWrapper.className = 'pixel-fields';
+  pixelWrapper.appendChild(createLabeledInput('Ширина тайла', pixelWidthInput));
+  pixelWrapper.appendChild(createLabeledInput('Высота тайла', pixelHeightInput));
+  pixelWrapper.appendChild(createLabeledInput('Высота уровня', pixelElevationInput));
+  settingsForm.appendChild(pixelWrapper);
+
+  function syncPixelVisibility(): void {
+    pixelWrapper.style.display = mapState.hex.orientation === 'isometric' ? 'grid' : 'none';
+  }
+
+  syncPixelVisibility();
+
+  function ensurePixelMetrics(): void {
+    if (mapState.hex.orientation !== 'isometric') {
+      return;
+    }
+    mapState.hex.pixel = {
+      tileWidth: Number.parseInt(pixelWidthInput.value, 10) || 80,
+      tileHeight: Number.parseInt(pixelHeightInput.value, 10) || 36,
+      elevation: Number.parseInt(pixelElevationInput.value, 10) || 96,
+    };
+  }
+
+  pixelWidthInput.addEventListener('change', () => {
+    ensurePixelMetrics();
+    void refreshPreview();
+  });
+  pixelHeightInput.addEventListener('change', () => {
+    ensurePixelMetrics();
+    void refreshPreview();
+  });
+  pixelElevationInput.addEventListener('change', () => {
+    ensurePixelMetrics();
+    void refreshPreview();
+  });
+
+  orientationSelect.addEventListener('change', () => {
+    syncPixelVisibility();
+  });
+
+  paletteSearch.addEventListener('input', () => {
+    renderAssetPalette();
+  });
+
+  function renderAssetPalette(): void {
+    const filter = paletteSearch.value.trim().toLowerCase();
+    paletteList.innerHTML = '';
+    const groups = new Map<string, AssetCatalogEntry[]>();
+    for (const asset of assets) {
+      if (filter) {
+        const haystack = `${asset.folder}/${asset.name}/${asset.originalPath}`.toLowerCase();
+        if (!haystack.includes(filter)) {
+          continue;
+        }
+      }
+      const list = groups.get(asset.folder) ?? [];
+      list.push(asset);
+      groups.set(asset.folder, list);
+    }
+
+    const sortedGroups = [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+    if (sortedGroups.length === 0) {
+      const empty = document.createElement('p');
+      empty.textContent = 'Ассеты не найдены';
+      paletteList.appendChild(empty);
+      return;
+    }
+
+    for (const [folder, entries] of sortedGroups) {
+      const details = document.createElement('details');
+      details.open = true;
+      const summaryEl = document.createElement('summary');
+      summaryEl.textContent = `${folder} (${entries.length})`;
+      details.appendChild(summaryEl);
+
+      const grid = document.createElement('div');
+      grid.className = 'asset-grid';
+      for (const asset of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'asset-item';
+        if (selectedAsset?.id === asset.id) {
+          button.classList.add('selected');
+        }
+
+        const preview = document.createElement('img');
+        preview.loading = 'lazy';
+        preview.alt = asset.name;
+        preview.src = `/art/${asset.id}/dir_0/frame_00.png`;
+        button.appendChild(preview);
+
+        const caption = document.createElement('span');
+        caption.textContent = asset.name;
+        button.appendChild(caption);
+
+        button.addEventListener('click', () => {
+          selectedAsset = asset;
+          updateSelectionInfo();
+          renderAssetPalette();
+        });
+
+        grid.appendChild(button);
+      }
+      details.appendChild(grid);
+      paletteList.appendChild(details);
+    }
+  }
+
+  async function loadAssets(): Promise<void> {
+    if (assetsLoaded) {
+      return;
+    }
+    setStatus('Загружаем ассеты…');
+    try {
+      const response = await fetch('/api/assets');
+      if (!response.ok) {
+        throw new Error(`${response.status} ${response.statusText}`);
+      }
+      const data = (await response.json()) as AssetCatalogEntry[];
+      assets = data;
+      assetLookup.clear();
+      for (const entry of assets) {
+        assetLookup.set(entry.id, entry);
+      }
+      assetsLoaded = true;
+      renderAssetPalette();
+      updateSelectionInfo();
+      updateSummary();
+      setStatus('Ассеты загружены');
+    } catch (error) {
+      console.error(error);
+      setStatus('Не удалось загрузить ассеты', true);
+    }
+  }
+
+  exportButton.addEventListener('click', () => {
+    const exportData = buildMapData();
+    const serializable = {
+      id: exportData.id,
+      name: exportData.name,
+      hex: exportData.hex,
+      size: exportData.size,
+      tiles: exportData.tiles.map(({ layer, q, r, art }) => ({ layer, q, r, art })),
+      objects: exportData.objects.map(({ id, q, r, elev, dir, art }) => ({ id, q, r, elev, dir, art })),
+    };
+    exportOutput.value = JSON.stringify(serializable, null, 2);
+    setStatus('JSON обновлён');
+  });
+
+  downloadButton.addEventListener('click', () => {
+    if (!exportOutput.value) {
+      setStatus('Сначала сформируйте JSON', true);
+      return;
+    }
+    const blob = new Blob([exportOutput.value], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `${mapState.id}.json`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    setStatus('Файл скачан');
+  });
+
+  copyButton.addEventListener('click', async () => {
+    if (!exportOutput.value) {
+      setStatus('Нет данных для копирования', true);
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(exportOutput.value);
+      setStatus('JSON скопирован в буфер обмена');
+    } catch (error) {
+      console.error(error);
+      setStatus('Не удалось скопировать JSON', true);
+    }
+  });
+
+  const page: GeneratorPage = {
+    root,
+    activate() {
+      void loadAssets();
+      void refreshPreview();
+    },
+    deactivate() {
+      // noop
+    },
+  };
+
+  updateModeButtons();
+  updateSelectionInfo();
+  updateSummary();
+
+  return page;
+}

--- a/packages/client/src/main.ts
+++ b/packages/client/src/main.ts
@@ -1,370 +1,70 @@
 import './style.css';
 
-interface HexPixelMetrics {
-  tileWidth: number;
-  tileHeight: number;
-  elevation: number;
-}
+import { createGeneratorPage } from './generator';
+import { createViewerPage } from './viewer';
 
-interface HexGridInfo {
-  orientation: 'pointy' | 'flat' | 'isometric';
-  size: number;
-  pixel?: HexPixelMetrics;
-}
-
-interface MapTile {
-  q: number;
-  r: number;
-  layer: 'ground' | 'roof';
-  art: string;
-}
-
-interface MapObject {
+interface Page {
   id: string;
-  q: number;
-  r: number;
-  elev: number;
-  dir: number;
-  art: string;
+  label: string;
+  root: HTMLElement;
+  activate(): void;
+  deactivate(): void;
 }
 
-interface MapData {
-  id: string;
-  hex: HexGridInfo;
-  size: { w: number; h: number };
-  tiles: MapTile[];
-  objects: MapObject[];
-  assets: Record<string, AssetDescriptor | undefined>;
+interface PageWithButton extends Page {
+  button?: HTMLButtonElement;
 }
 
-interface AssetDescriptor {
-  kind: string;
-  category: string;
-  outDir: string;
-  dirs: number;
-  framesPerDir: number;
-  size: { maxW: number; maxH: number };
-  anchorAvg: { xOff: number; yOff: number };
+const app = document.getElementById('app');
+if (!app) {
+  throw new Error('Root element not found');
 }
 
-interface MapSummary {
-  id: string;
-  name: string;
-  hex: HexGridInfo;
-  tiles: number;
-  objects: number;
+const nav = document.createElement('nav');
+nav.className = 'app-nav';
+
+const container = document.createElement('div');
+container.className = 'page-container';
+
+const viewer = createViewerPage();
+const generator = createGeneratorPage();
+
+const pages: PageWithButton[] = [
+  { id: 'viewer', label: 'Просмотр карт', ...viewer },
+  { id: 'generator', label: 'Генератор JSON', ...generator },
+];
+
+let currentPage: PageWithButton | null = null;
+
+for (const page of pages) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = page.label;
+  button.className = 'nav-button';
+  button.addEventListener('click', () => switchTo(page));
+  nav.appendChild(button);
+  page.button = button;
 }
 
-type ImageCache = Map<string, HTMLImageElement>;
-
-const app = document.getElementById('app')!;
-
-const toolbar = document.createElement('div');
-toolbar.className = 'toolbar';
-
-const title = document.createElement('h1');
-title.textContent = 'TLA 3.0 • Map Viewer';
-toolbar.appendChild(title);
-
-const select = document.createElement('select');
-toolbar.appendChild(select);
-
-const viewer = document.createElement('div');
-viewer.className = 'viewer';
-
-const status = document.createElement('div');
-status.className = 'status';
-viewer.appendChild(status);
-
-const canvas = document.createElement('canvas');
-viewer.appendChild(canvas);
-
-app.append(toolbar, viewer);
-
-let maps: MapSummary[] = [];
-let currentMap: MapData | null = null;
-
-async function fetchJson<T>(url: string): Promise<T> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`);
-  }
-  return (await response.json()) as T;
-}
-
-async function loadMapsList(): Promise<void> {
-  status.textContent = 'Загружаем карты…';
-  status.classList.remove('error');
-  try {
-    maps = await fetchJson<MapSummary[]>('/api/maps');
-    select.innerHTML = '';
-    for (const entry of maps) {
-      const option = document.createElement('option');
-      option.value = entry.id;
-      option.textContent = `${entry.name} (${entry.tiles} плиток, ${entry.objects} объектов)`;
-      select.appendChild(option);
-    }
-    if (maps.length > 0) {
-      await loadMap(maps[0].id);
-    } else {
-      status.textContent = 'Не найдено ни одной карты';
-    }
-  } catch (error) {
-    console.error(error);
-    status.textContent = 'Ошибка загрузки списка карт';
-    status.classList.add('error');
-  }
-}
-
-async function loadMap(mapId: string): Promise<void> {
-  status.textContent = 'Загружаем карту…';
-  status.classList.remove('error');
-  try {
-    currentMap = await fetchJson<MapData>(`/api/maps/${encodeURIComponent(mapId)}`);
-    await renderCurrentMap();
-    status.textContent = '';
-  } catch (error) {
-    console.error(error);
-    status.textContent = 'Не удалось загрузить карту';
-    status.classList.add('error');
-  }
-}
-
-select.addEventListener('change', (event: Event) => {
-  const target = event.target as HTMLSelectElement | null;
-  if (target && target.value) {
-    loadMap(target.value).catch((error) => console.error('Map load failed', error));
-  }
-});
-
-const ISO_DEFAULT_METRICS: HexPixelMetrics = { tileWidth: 80, tileHeight: 36, elevation: 96 };
-
-function getPixelMetrics(hex: HexGridInfo): HexPixelMetrics {
-  if (hex.pixel) {
-    return hex.pixel;
-  }
-  if (hex.orientation === 'isometric') {
-    return ISO_DEFAULT_METRICS;
-  }
-  const baseSize = Math.max(1, hex.size);
-  const tileWidth = Math.sqrt(3) * baseSize;
-  const tileHeight = 2 * baseSize;
-  const elevation = tileHeight * 1.5;
-  return { tileWidth, tileHeight, elevation };
-}
-
-function projectHex(q: number, r: number, hex: HexGridInfo, elev = 0): { x: number; y: number } {
-  const metrics = getPixelMetrics(hex);
-  if (hex.orientation === 'isometric') {
-    const x = (q - r) * (metrics.tileWidth / 2);
-    const y = (q + r) * (metrics.tileHeight / 2) - elev * metrics.elevation;
-    return { x, y };
-  }
-
-  const size = Math.max(1, hex.size);
-  if (hex.orientation === 'flat') {
-    const x = size * (3 / 2) * q;
-    const y = size * Math.sqrt(3) * (r + q / 2) - elev * metrics.elevation;
-    return { x, y };
-  }
-
-  const x = size * Math.sqrt(3) * (q + r / 2);
-  const y = size * (3 / 2) * r - elev * metrics.elevation;
-  return { x, y };
-}
-
-function buildImageUrl(art: string, dir: number, frame: number): string {
-  const frameIndex = Math.max(0, frame);
-  const frameName = frameIndex.toString().padStart(2, '0');
-  return `/art/${art}/dir_${dir}/frame_${frameName}.png`;
-}
-
-async function loadImages(map: MapData): Promise<ImageCache> {
-  const cache: ImageCache = new Map();
-  const promises: Promise<void>[] = [];
-
-  const queue = new Set<string>();
-
-  for (const tile of map.tiles) {
-    queue.add(buildImageUrl(tile.art, 0, 0));
-  }
-  for (const object of map.objects) {
-    const dir = object.dir ?? 0;
-    queue.add(buildImageUrl(object.art, dir, 0));
-  }
-
-  for (const url of queue) {
-    promises.push(
-      new Promise((resolve) => {
-        const img = new Image();
-        img.onload = () => {
-          cache.set(url, img);
-          resolve();
-        };
-        img.onerror = () => {
-          console.warn('Asset failed to load:', url);
-          resolve();
-        };
-        img.src = url;
-      }),
-    );
-  }
-
-  await Promise.all(promises);
-  return cache;
-}
-
-function getAssetInfo(map: MapData, art: string): AssetDescriptor | null {
-  const direct = map.assets[art];
-  if (direct) {
-    return direct;
-  }
-  const lower = map.assets[art.toLowerCase()];
-  if (lower) {
-    return lower;
-  }
-  const upper = map.assets[art.toUpperCase()];
-  if (upper) {
-    return upper;
-  }
-  return null;
-}
-
-function computeDrawMetrics(
-  map: MapData,
-  images: ImageCache,
-): {
-  drawables: {
-    layer: 'ground' | 'roof' | 'object';
-    x: number;
-    y: number;
-    z: number;
-    image: HTMLImageElement;
-    art: string;
-  }[];
-  bounds: { minX: number; minY: number; maxX: number; maxY: number };
-} {
-  const drawables: {
-    layer: 'ground' | 'roof' | 'object';
-    x: number;
-    y: number;
-    z: number;
-    image: HTMLImageElement;
-    art: string;
-  }[] = [];
-
-  let minX = Number.POSITIVE_INFINITY;
-  let minY = Number.POSITIVE_INFINITY;
-  let maxX = Number.NEGATIVE_INFINITY;
-  let maxY = Number.NEGATIVE_INFINITY;
-
-  const pushDrawable = (
-    layer: 'ground' | 'roof' | 'object',
-    q: number,
-    r: number,
-    image: HTMLImageElement,
-    art: string,
-    elev = 0,
-  ) => {
-    const asset = getAssetInfo(map, art);
-    const base = projectHex(q, r, map.hex, elev);
-    const anchorX = asset?.anchorAvg.xOff ?? 0;
-    const anchorY = asset?.anchorAvg.yOff ?? 0;
-    const rawX = base.x + anchorX - image.width / 2;
-    const rawY = base.y + anchorY - image.height;
-    const drawX = Math.round(rawX);
-    const drawY = Math.round(rawY);
-    minX = Math.min(minX, drawX);
-    minY = Math.min(minY, drawY);
-    maxX = Math.max(maxX, drawX + image.width);
-    maxY = Math.max(maxY, drawY + image.height);
-    const z = base.y;
-    drawables.push({ layer, x: drawX, y: drawY, z, image, art });
-  };
-
-  for (const tile of map.tiles) {
-    const url = buildImageUrl(tile.art, 0, 0);
-    const img = images.get(url);
-    if (!img) {
-      continue;
-    }
-    pushDrawable(tile.layer, tile.q, tile.r, img, tile.art);
-  }
-
-  for (const object of map.objects) {
-    const dir = object.dir ?? 0;
-    const url = buildImageUrl(object.art, dir, 0);
-    const fallbackUrl = buildImageUrl(object.art, 0, 0);
-    const img = images.get(url) ?? images.get(fallbackUrl);
-    if (!img) {
-      continue;
-    }
-    pushDrawable('object', object.q, object.r, img, object.art, object.elev ?? 0);
-  }
-
-  return {
-    drawables,
-    bounds: {
-      minX,
-      minY,
-      maxX,
-      maxY,
-    },
-  };
-}
-
-async function renderCurrentMap(): Promise<void> {
-  const map = currentMap;
-  if (!map) {
+function switchTo(page: PageWithButton): void {
+  if (currentPage?.id === page.id) {
     return;
   }
-
-  const ctx = canvas.getContext('2d');
-  if (!ctx) {
-    throw new Error('Canvas not supported');
+  if (currentPage) {
+    currentPage.deactivate();
+    container.innerHTML = '';
+    if (currentPage.button) {
+      currentPage.button.classList.remove('active');
+    }
   }
-
-  const images = await loadImages(map);
-  const { drawables, bounds } = computeDrawMetrics(map, images);
-
-  if (!Number.isFinite(bounds.minX)) {
-    status.textContent = 'Карта пустая';
-    return;
+  container.appendChild(page.root);
+  page.activate();
+  if (page.button) {
+    page.button.classList.add('active');
   }
-
-  const padding = 64;
-  const width = Math.ceil(bounds.maxX - bounds.minX + padding * 2);
-  const height = Math.ceil(bounds.maxY - bounds.minY + padding * 2);
-
-  const dpr = window.devicePixelRatio || 1;
-  canvas.width = width * dpr;
-  canvas.height = height * dpr;
-  canvas.style.width = `${width}px`;
-  canvas.style.height = `${height}px`;
-
-  ctx.resetTransform();
-  ctx.scale(dpr, dpr);
-  ctx.imageSmoothingEnabled = false;
-  ctx.clearRect(0, 0, width, height);
-
-  const offsetX = -bounds.minX + padding;
-  const offsetY = -bounds.minY + padding;
-
-  drawables
-    .sort((a, b) => {
-      if (a.layer === b.layer) {
-        return a.z - b.z;
-      }
-      const order = { ground: 0, roof: 1, object: 2 };
-      return order[a.layer] - order[b.layer];
-    })
-    .forEach((drawable) => {
-      ctx.drawImage(drawable.image, drawable.x + offsetX, drawable.y + offsetY);
-    });
+  currentPage = page;
 }
 
-loadMapsList().catch((error) => {
-  console.error(error);
-  status.textContent = 'Ошибка инициализации клиента';
-  status.classList.add('error');
-});
+app.append(nav, container);
+
+switchTo(pages[0]!);

--- a/packages/client/src/rendering.ts
+++ b/packages/client/src/rendering.ts
@@ -1,0 +1,225 @@
+import type { HexGridInfo, HexPixelMetrics, ImageCache, MapData } from './types';
+
+const ISO_DEFAULT_METRICS: HexPixelMetrics = { tileWidth: 80, tileHeight: 36, elevation: 96 };
+
+export function getPixelMetrics(hex: HexGridInfo): HexPixelMetrics {
+  if (hex.pixel) {
+    return hex.pixel;
+  }
+  if (hex.orientation === 'isometric') {
+    return ISO_DEFAULT_METRICS;
+  }
+  const baseSize = Math.max(1, hex.size);
+  const tileWidth = Math.sqrt(3) * baseSize;
+  const tileHeight = 2 * baseSize;
+  const elevation = tileHeight * 1.5;
+  return { tileWidth, tileHeight, elevation };
+}
+
+export function projectHex(q: number, r: number, hex: HexGridInfo, elev = 0): { x: number; y: number } {
+  const metrics = getPixelMetrics(hex);
+  if (hex.orientation === 'isometric') {
+    const x = (q - r) * (metrics.tileWidth / 2);
+    const y = (q + r) * (metrics.tileHeight / 2) - elev * metrics.elevation;
+    return { x, y };
+  }
+
+  const size = Math.max(1, hex.size);
+  if (hex.orientation === 'flat') {
+    const x = size * (3 / 2) * q;
+    const y = size * Math.sqrt(3) * (r + q / 2) - elev * metrics.elevation;
+    return { x, y };
+  }
+
+  const x = size * Math.sqrt(3) * (q + r / 2);
+  const y = size * (3 / 2) * r - elev * metrics.elevation;
+  return { x, y };
+}
+
+export function buildImageUrl(art: string, dir: number, frame: number): string {
+  const frameIndex = Math.max(0, frame);
+  const frameName = frameIndex.toString().padStart(2, '0');
+  return `/art/${art}/dir_${dir}/frame_${frameName}.png`;
+}
+
+export function collectImageUrls(map: MapData): Set<string> {
+  const urls = new Set<string>();
+  for (const tile of map.tiles) {
+    urls.add(buildImageUrl(tile.art, 0, 0));
+  }
+  for (const object of map.objects) {
+    const dir = object.dir ?? 0;
+    urls.add(buildImageUrl(object.art, dir, 0));
+    urls.add(buildImageUrl(object.art, 0, 0));
+  }
+  return urls;
+}
+
+export async function ensureImages(urls: Iterable<string>, cache: ImageCache): Promise<ImageCache> {
+  const promises: Promise<void>[] = [];
+  for (const url of urls) {
+    if (cache.has(url)) {
+      continue;
+    }
+    promises.push(
+      new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+          cache.set(url, img);
+          resolve();
+        };
+        img.onerror = () => {
+          // eslint-disable-next-line no-console
+          console.warn('Asset failed to load:', url);
+          resolve();
+        };
+        img.src = url;
+      }),
+    );
+  }
+  if (promises.length > 0) {
+    await Promise.all(promises);
+  }
+  return cache;
+}
+
+interface Drawable {
+  layer: 'ground' | 'roof' | 'object';
+  x: number;
+  y: number;
+  z: number;
+  art: string;
+  image: HTMLImageElement;
+}
+
+interface Bounds {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+function getAssetInfo(map: MapData, art: string) {
+  return map.assets?.[art];
+}
+
+function computeDrawables(map: MapData, images: ImageCache): { drawables: Drawable[]; bounds: Bounds } {
+  const drawables: Drawable[] = [];
+  let minX = Number.POSITIVE_INFINITY;
+  let minY = Number.POSITIVE_INFINITY;
+  let maxX = Number.NEGATIVE_INFINITY;
+  let maxY = Number.NEGATIVE_INFINITY;
+
+  const pushDrawable = (
+    layer: 'ground' | 'roof' | 'object',
+    q: number,
+    r: number,
+    image: HTMLImageElement,
+    art: string,
+    elev = 0,
+  ) => {
+    const asset = getAssetInfo(map, art);
+    const base = projectHex(q, r, map.hex, elev);
+    const anchorX = asset?.anchorAvg.xOff ?? 0;
+    const anchorY = asset?.anchorAvg.yOff ?? 0;
+    const rawX = base.x + anchorX - image.width / 2;
+    const rawY = base.y + anchorY - image.height;
+    const drawX = Math.round(rawX);
+    const drawY = Math.round(rawY);
+    minX = Math.min(minX, drawX);
+    minY = Math.min(minY, drawY);
+    maxX = Math.max(maxX, drawX + image.width);
+    maxY = Math.max(maxY, drawY + image.height);
+    const z = base.y;
+    drawables.push({ layer, x: drawX, y: drawY, z, art, image });
+  };
+
+  for (const tile of map.tiles) {
+    const url = buildImageUrl(tile.art, 0, 0);
+    const img = images.get(url);
+    if (!img) {
+      continue;
+    }
+    pushDrawable(tile.layer, tile.q, tile.r, img, tile.art);
+  }
+
+  for (const object of map.objects) {
+    const dir = object.dir ?? 0;
+    const url = buildImageUrl(object.art, dir, 0);
+    const fallbackUrl = buildImageUrl(object.art, 0, 0);
+    const img = images.get(url) ?? images.get(fallbackUrl);
+    if (!img) {
+      continue;
+    }
+    pushDrawable('object', object.q, object.r, img, object.art, object.elev ?? 0);
+  }
+
+  return {
+    drawables,
+    bounds: { minX, minY, maxX, maxY },
+  };
+}
+
+export interface DrawResult {
+  ctx: CanvasRenderingContext2D;
+  dpr: number;
+  width: number;
+  height: number;
+  offsetX: number;
+  offsetY: number;
+  bounds: Bounds;
+  images: ImageCache;
+}
+
+export async function drawMap(
+  canvas: HTMLCanvasElement,
+  map: MapData,
+  cache: ImageCache,
+): Promise<DrawResult> {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Canvas not supported');
+  }
+
+  const urls = collectImageUrls(map);
+  await ensureImages(urls, cache);
+
+  const { drawables, bounds } = computeDrawables(map, cache);
+
+  const padding = 64;
+  const hasContent = Number.isFinite(bounds.minX);
+  const width = hasContent ? Math.ceil(bounds.maxX - bounds.minX + padding * 2) : 512;
+  const height = hasContent ? Math.ceil(bounds.maxY - bounds.minY + padding * 2) : 512;
+
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+
+  ctx.resetTransform();
+  ctx.scale(dpr, dpr);
+  ctx.imageSmoothingEnabled = false;
+  ctx.clearRect(0, 0, width, height);
+
+  if (!hasContent) {
+    return { ctx, dpr, width, height, offsetX: padding, offsetY: padding, bounds, images: cache };
+  }
+
+  const offsetX = -bounds.minX + padding;
+  const offsetY = -bounds.minY + padding;
+
+  drawables
+    .sort((a, b) => {
+      if (a.layer === b.layer) {
+        return a.z - b.z;
+      }
+      const order = { ground: 0, roof: 1, object: 2 } as const;
+      return order[a.layer] - order[b.layer];
+    })
+    .forEach((drawable) => {
+      ctx.drawImage(drawable.image, drawable.x + offsetX, drawable.y + offsetY);
+    });
+
+  return { ctx, dpr, width, height, offsetX, offsetY, bounds, images: cache };
+}

--- a/packages/client/src/style.css
+++ b/packages/client/src/style.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: dark;
   font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
-  background: #101418;
-  color: #f1f5f9;
+  background: #0f172a;
+  color: #e2e8f0;
 }
 
 html,
@@ -17,14 +17,71 @@ body,
 body {
   display: flex;
   flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(30, 64, 175, 0.25), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(14, 165, 233, 0.2), transparent 45%), #0f172a;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.app-nav {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(18px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.nav-button {
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.nav-button:hover {
+  border-color: rgba(96, 165, 250, 0.7);
+  color: #bfdbfe;
+}
+
+.nav-button.active {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.25), rgba(56, 189, 248, 0.3));
+  border-color: rgba(56, 189, 248, 0.75);
+  color: #f8fafc;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.45);
+}
+
+.page-container {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+}
+
+.viewer-page,
+.generator-page {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 0.75rem 1.5rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.85rem 1.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
   background: rgba(15, 23, 42, 0.75);
   backdrop-filter: blur(16px);
 }
@@ -33,13 +90,14 @@ body {
   font-size: 1rem;
   font-weight: 600;
   margin: 0;
+  letter-spacing: 0.01em;
 }
 
 .toolbar select {
-  padding: 0.35rem 0.75rem;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(15, 23, 42, 0.9);
+  padding: 0.4rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
   color: inherit;
   font-size: 0.95rem;
 }
@@ -53,12 +111,15 @@ body {
   position: relative;
   flex: 1;
   overflow: auto;
+  padding: 1.5rem;
 }
 
 .viewer canvas {
   display: block;
   margin: 0 auto;
-  background: transparent;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.85), rgba(15, 23, 42, 0.65));
+  border-radius: 1rem;
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.45);
   image-rendering: pixelated;
 }
 
@@ -75,4 +136,306 @@ body {
 
 .status.error {
   color: #fca5a5;
+}
+
+.generator-page {
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) 1fr;
+  gap: 0;
+}
+
+.generator-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-right: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  overflow: auto;
+}
+
+.generator-content {
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.5rem;
+  gap: 1rem;
+  overflow: auto;
+}
+
+.generator-section {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 1rem;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.generator-section h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: #bfdbfe;
+}
+
+.generator-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.form-field input,
+.form-field select {
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+.field-hint {
+  font-size: 0.75rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.pixel-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.asset-search {
+  width: 100%;
+  padding: 0.45rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+.asset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 45vh;
+  overflow: auto;
+}
+
+.asset-list details {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.asset-list summary {
+  padding: 0.45rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.asset-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 0.6rem;
+  padding: 0.6rem;
+}
+
+.asset-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: center;
+  padding: 0.35rem;
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  font-size: 0.75rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.asset-item:hover {
+  border-color: rgba(96, 165, 250, 0.6);
+  transform: translateY(-2px);
+}
+
+.asset-item.selected {
+  border-color: rgba(56, 189, 248, 0.8);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.45);
+}
+
+.asset-item img {
+  width: 64px;
+  height: 64px;
+  object-fit: contain;
+  image-rendering: pixelated;
+  filter: drop-shadow(0 4px 8px rgba(15, 23, 42, 0.6));
+}
+
+.generator-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.mode-button {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.mode-button.active {
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35), rgba(56, 189, 248, 0.35));
+  border-color: rgba(56, 189, 248, 0.85);
+  color: #f8fafc;
+}
+
+.selection-info {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+  flex: 1;
+  min-width: 180px;
+}
+
+.object-controls {
+  display: none;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.object-controls label {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.object-controls input {
+  width: 4rem;
+  padding: 0.3rem 0.45rem;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.9);
+  color: inherit;
+}
+
+.generator-canvas-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 400px;
+}
+
+.generator-canvas {
+  display: block;
+  max-width: 100%;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.7));
+  border-radius: 1rem;
+  image-rendering: pixelated;
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.55);
+}
+
+.generator-status {
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.85);
+  padding: 0 0.25rem;
+}
+
+.generator-status.error {
+  color: #fca5a5;
+}
+
+.generator-summary {
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.9);
+  padding: 0.5rem 0.25rem;
+}
+
+.export-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.export-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.export-actions button {
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.export-actions button:hover {
+  border-color: rgba(96, 165, 250, 0.75);
+  color: #bfdbfe;
+}
+
+.export-output {
+  width: 100%;
+  min-height: 200px;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.85);
+  color: inherit;
+  padding: 0.75rem;
+  font-family: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.85rem;
+  resize: vertical;
+}
+
+@media (max-width: 1024px) {
+  .generator-page {
+    grid-template-columns: minmax(280px, 320px) 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .generator-page {
+    grid-template-columns: 1fr;
+  }
+
+  .generator-sidebar {
+    border-right: none;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  }
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,0 +1,57 @@
+export interface HexPixelMetrics {
+  tileWidth: number;
+  tileHeight: number;
+  elevation: number;
+}
+
+export interface HexGridInfo {
+  orientation: 'pointy' | 'flat' | 'isometric';
+  size: number;
+  pixel?: HexPixelMetrics;
+}
+
+export interface MapTile {
+  q: number;
+  r: number;
+  layer: 'ground' | 'roof';
+  art: string;
+}
+
+export interface MapObject {
+  id: string;
+  q: number;
+  r: number;
+  elev: number;
+  dir: number;
+  art: string;
+}
+
+export interface MapData {
+  id: string;
+  name?: string;
+  hex: HexGridInfo;
+  size: { w: number; h: number };
+  tiles: MapTile[];
+  objects: MapObject[];
+  assets?: Record<string, AssetDescriptor | undefined>;
+}
+
+export interface AssetDescriptor {
+  kind: string;
+  category: string;
+  outDir: string;
+  dirs: number;
+  framesPerDir: number;
+  size: { maxW: number; maxH: number };
+  anchorAvg: { xOff: number; yOff: number };
+}
+
+export interface MapSummary {
+  id: string;
+  name: string;
+  hex: HexGridInfo;
+  tiles: number;
+  objects: number;
+}
+
+export type ImageCache = Map<string, HTMLImageElement>;

--- a/packages/client/src/viewer.ts
+++ b/packages/client/src/viewer.ts
@@ -1,0 +1,125 @@
+import { drawMap } from './rendering';
+import type { ImageCache, MapData, MapSummary } from './types';
+
+interface ViewerPage {
+  root: HTMLElement;
+  activate(): void;
+  deactivate(): void;
+}
+
+export function createViewerPage(): ViewerPage {
+  const root = document.createElement('div');
+  root.className = 'viewer-page';
+
+  const toolbar = document.createElement('div');
+  toolbar.className = 'toolbar';
+
+  const title = document.createElement('h1');
+  title.textContent = 'TLA 3.0 • Map Viewer';
+  toolbar.appendChild(title);
+
+  const select = document.createElement('select');
+  toolbar.appendChild(select);
+
+  const viewer = document.createElement('div');
+  viewer.className = 'viewer';
+
+  const status = document.createElement('div');
+  status.className = 'status';
+  viewer.appendChild(status);
+
+  const canvas = document.createElement('canvas');
+  viewer.appendChild(canvas);
+
+  root.append(toolbar, viewer);
+
+  let maps: MapSummary[] = [];
+  let currentMap: MapData | null = null;
+  const imageCache: ImageCache = new Map();
+  let initialized = false;
+
+  async function fetchJson<T>(url: string): Promise<T> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  async function loadMapsList(): Promise<void> {
+    status.textContent = 'Загружаем карты…';
+    status.classList.remove('error');
+    try {
+      maps = await fetchJson<MapSummary[]>('/api/maps');
+      select.innerHTML = '';
+      for (const entry of maps) {
+        const option = document.createElement('option');
+        option.value = entry.id;
+        option.textContent = `${entry.name} (${entry.tiles} плиток, ${entry.objects} объектов)`;
+        select.appendChild(option);
+      }
+      if (maps.length > 0) {
+        await loadMap(maps[0].id);
+      } else {
+        status.textContent = 'Не найдено ни одной карты';
+      }
+    } catch (error) {
+      console.error(error);
+      status.textContent = 'Ошибка загрузки списка карт';
+      status.classList.add('error');
+    }
+  }
+
+  async function loadMap(mapId: string): Promise<void> {
+    status.textContent = 'Загружаем карту…';
+    status.classList.remove('error');
+    try {
+      currentMap = await fetchJson<MapData>(`/api/maps/${encodeURIComponent(mapId)}`);
+      await renderCurrentMap();
+      status.textContent = '';
+    } catch (error) {
+      console.error(error);
+      status.textContent = 'Не удалось загрузить карту';
+      status.classList.add('error');
+    }
+  }
+
+  async function renderCurrentMap(): Promise<void> {
+    const map = currentMap;
+    if (!map) {
+      return;
+    }
+    const result = await drawMap(canvas, map, imageCache);
+    if (!Number.isFinite(result.bounds.minX)) {
+      status.textContent = 'Карта пустая';
+    }
+  }
+
+  select.addEventListener('change', (event: Event) => {
+    const target = event.target as HTMLSelectElement | null;
+    if (target && target.value) {
+      loadMap(target.value).catch((error) => console.error('Map load failed', error));
+    }
+  });
+
+  const page: ViewerPage = {
+    root,
+    activate() {
+      if (!initialized) {
+        initialized = true;
+        loadMapsList().catch((error) => {
+          console.error(error);
+          status.textContent = 'Ошибка инициализации клиента';
+          status.classList.add('error');
+        });
+      } else if (currentMap) {
+        renderCurrentMap().catch((error) => console.error('Render failed', error));
+      }
+    },
+    deactivate() {
+      // noop
+    },
+  };
+
+  return page;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tla/server",
+  "name": "server",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,7 @@ import morgan from 'morgan';
 import { artRouter } from './assets';
 import { env } from './env';
 import { authRouter } from './routes/auth';
+import { assetsRouter } from './routes/assets';
 import { registerWsServer } from './ws/server';
 import { mapsRouter } from './routes/maps';
 
@@ -36,6 +37,7 @@ app.get('/healthz', (_req, res) => {
 });
 
 app.use('/api/auth', authRouter);
+app.use('/api/assets', assetsRouter);
 app.use('/api/maps', mapsRouter);
 app.use('/art', artRouter);
 

--- a/packages/server/src/routes/assets.ts
+++ b/packages/server/src/routes/assets.ts
@@ -1,0 +1,117 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Router } from 'express';
+
+interface AssetMapEntry {
+  id: string;
+  path_in: string;
+  kind: string;
+  category: string;
+  out_dir: string;
+  dirs: number;
+  framesPerDir: number;
+  size: { maxW: number; maxH: number };
+  anchorAvg: { xOff: number; yOff: number };
+}
+
+interface AssetResponse {
+  id: string;
+  folder: string;
+  name: string;
+  originalPath: string;
+  dirs: number;
+  framesPerDir: number;
+  descriptor: {
+    kind: string;
+    category: string;
+    outDir: string;
+    dirs: number;
+    framesPerDir: number;
+    size: { maxW: number; maxH: number };
+    anchorAvg: { xOff: number; yOff: number };
+  };
+}
+
+const ALLOWED_FOLDERS = new Set(['misc', 'scenery', 'skilldex', 'splash', 'tiles', 'walls']);
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(moduleDir, '../../../..');
+const assetMapPath = path.join(repoRoot, 'assets', 'asset_map.json');
+
+let cachedCatalog: AssetResponse[] | null = null;
+
+async function loadCatalog(): Promise<AssetResponse[]> {
+  if (cachedCatalog) {
+    return cachedCatalog;
+  }
+  const raw = await fs.readFile(assetMapPath, 'utf8');
+  const data = JSON.parse(raw) as AssetMapEntry[];
+  const catalog: AssetResponse[] = [];
+  for (const entry of data) {
+    const normalized = normalizeArtPath(entry.path_in);
+    if (!normalized) {
+      continue;
+    }
+    const [folder, ...rest] = normalized.split('/');
+    if (!folder || !ALLOWED_FOLDERS.has(folder)) {
+      continue;
+    }
+    if (rest.length === 0) {
+      continue;
+    }
+    const baseName = rest[rest.length - 1] ?? '';
+    const name = baseName.toUpperCase();
+    const id = normalized.replace(/\.frm$/i, '').toLowerCase();
+    catalog.push({
+      id,
+      folder,
+      name,
+      originalPath: entry.path_in,
+      dirs: entry.dirs,
+      framesPerDir: entry.framesPerDir,
+      descriptor: {
+        kind: entry.kind,
+        category: entry.category,
+        outDir: entry.out_dir,
+        dirs: entry.dirs,
+        framesPerDir: entry.framesPerDir,
+        size: entry.size,
+        anchorAvg: entry.anchorAvg,
+      },
+    });
+  }
+
+  catalog.sort((a, b) => {
+    if (a.folder === b.folder) {
+      return a.name.localeCompare(b.name);
+    }
+    return a.folder.localeCompare(b.folder);
+  });
+
+  cachedCatalog = catalog;
+  return catalog;
+}
+
+function normalizeArtPath(input: string): string | null {
+  if (!input) {
+    return null;
+  }
+  const unified = input.replace(/\\+/g, '/');
+  const withoutPrefix = unified.replace(/^art\//i, '');
+  return withoutPrefix;
+}
+
+const assetsRouter = Router();
+
+assetsRouter.get('/', async (_req, res, next) => {
+  try {
+    const catalog = await loadCatalog();
+    res.json(catalog);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export { assetsRouter };


### PR DESCRIPTION
## Summary
- add a tabbed client shell to switch between the existing map viewer and a new JSON map generator
- implement an interactive generator workspace with asset palette, canvas editing, preview rendering, and JSON export
- expose a filtered asset catalog API and refresh the client styling to support the new experience

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd02c9c3a8832cb5e89d7b25d02c96