### PR TITLE
feat(shared): port jsFO geometry helpers and pathfinding

### DIFF
--- a/packages/shared/src/geometry.test.ts
+++ b/packages/shared/src/geometry.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  convertHexIndexToScreenCoords,
+  convertScreenCoordsToHexIndex,
+  findAdjacentHexes,
+  findOrientation,
+  heuristicDistance,
+  MAP_HEX_WIDTH,
+} from './geometry.js';
+
+describe('geometry helpers', () => {
+  it('projects hex indexes to screen coordinates using jsFO math', () => {
+    expect(convertHexIndexToScreenCoords(0)).toEqual({ x: 0, y: 0 });
+    expect(convertHexIndexToScreenCoords(1)).toEqual({ x: -32, y: 0 });
+    expect(convertHexIndexToScreenCoords(MAP_HEX_WIDTH)).toEqual({ x: 16, y: 12 });
+  });
+
+  it('round-trips screen coordinates back to hex indexes', () => {
+    const index = MAP_HEX_WIDTH + 5;
+    const coords = convertHexIndexToScreenCoords(index);
+    expect(convertScreenCoordsToHexIndex(coords.x, coords.y)).toBe(index);
+  });
+
+  it('matches jsFO adjacency ordering for odd and even columns', () => {
+    expect(findAdjacentHexes(1)).toEqual([-200, 0, 201, 2, -198, -199]);
+    expect(findAdjacentHexes(2)).toEqual([1, 201, 202, 203, 3, -198]);
+  });
+
+  it('computes orientation index compatible with jsFO', () => {
+    expect(findOrientation(1, 0)).toBe(1);
+    expect(findOrientation(2, 203)).toBe(3);
+  });
+
+  it('estimates distance using screen-space heuristic', () => {
+    const dist = heuristicDistance(0, MAP_HEX_WIDTH + 1);
+    expect(dist).toBeCloseTo(Math.hypot(16, 12));
+  });
+});

--- a/packages/shared/src/geometry.ts
+++ b/packages/shared/src/geometry.ts
@@ -1,0 +1,119 @@
+export interface HexScreenPoint {
+  x: number;
+  y: number;
+}
+
+export interface GeometryOptions {
+  width?: number;
+  tileColumns?: number;
+}
+
+export const MAP_TILE_COLUMNS = 100;
+export const MAP_HEX_WIDTH = 200;
+export const MAP_ROOF_HEIGHT = 96;
+export const MAP_ALIGNMENT_OFFSET = { x: 48, y: -3 } as const;
+
+function resolveWidth(width?: number): number {
+  return typeof width === 'number' && Number.isFinite(width) && width > 0 ? Math.trunc(width) : MAP_HEX_WIDTH;
+}
+
+function resolveTileColumns(columns?: number): number {
+  return typeof columns === 'number' && Number.isFinite(columns) && columns > 0
+    ? Math.trunc(columns)
+    : MAP_TILE_COLUMNS;
+}
+
+export function convertHexIndexToScreenCoords(index: number, options: GeometryOptions = {}): HexScreenPoint {
+  const width = resolveWidth(options.width);
+  const q = index % width;
+  const r = Math.floor(index / width);
+  const px = 0 - q * 32 + r * 16;
+  const py = r * 12;
+  const qx = Math.floor(q / 2) * 16;
+  const qy = Math.floor(q / 2) * 12;
+  return { x: px + qx, y: py + qy };
+}
+
+export function convertTileIndexToScreenCoords(index: number, options: GeometryOptions = {}): HexScreenPoint {
+  const columns = resolveTileColumns(options.tileColumns);
+  const tCol = index % columns;
+  const tRow = Math.floor(index / columns);
+  return {
+    x: 0 - MAP_ALIGNMENT_OFFSET.x - tCol * 48 + tRow * 32,
+    y: MAP_ALIGNMENT_OFFSET.y + tCol * 12 + tRow * 24,
+  };
+}
+
+export function convertScreenCoordsToHexIndex(mx: number, my: number, options: GeometryOptions = {}): number {
+  const width = resolveWidth(options.width);
+  let adjustedX = mx;
+  if (adjustedX < 0) {
+    adjustedX -= 32;
+  }
+  adjustedX *= -1;
+  let hCol = Math.floor(adjustedX / 32);
+  let hRow = Math.floor(my / 12);
+  if (hRow > 0) {
+    hCol += Math.floor(Math.abs(hRow) / 2);
+  }
+  hRow -= Math.floor(hCol / 2);
+  return hRow * width + hCol;
+}
+
+export function findAdjacentHexes(index: number, options: GeometryOptions = {}): number[] {
+  const width = resolveWidth(options.width);
+  const column = index % width;
+  const isOddColumn = column % 2 !== 0;
+  const northWest = isOddColumn ? index - (width + 1) : index - 1;
+  const northEast = isOddColumn ? index - 1 : index + (width - 1);
+  const south = index + width;
+  const southEast = isOddColumn ? index + 1 : index + (width + 1);
+  const southWest = isOddColumn ? index - (width - 1) : index + 1;
+  const north = index - width;
+  return [northWest, northEast, south, southEast, southWest, north];
+}
+
+export function findOrientation(origin: number, dest: number, options: GeometryOptions = {}): number {
+  if (origin === dest) {
+    throw new Error('Origin and destination hexes are identical');
+  }
+  const neighbors = findAdjacentHexes(origin, options);
+  const orientation = neighbors.indexOf(dest);
+  if (orientation === -1) {
+    throw new Error('Destination hex is not adjacent to origin');
+  }
+  return orientation;
+}
+
+export function heuristicDistance(a: number, b: number, options: GeometryOptions = {}): number {
+  const start = convertHexIndexToScreenCoords(a, options);
+  const end = convertHexIndexToScreenCoords(b, options);
+  const dx = Math.abs(end.x - start.x);
+  const dy = Math.abs(end.y - start.y);
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function toHexIndex(q: number, r: number, options: GeometryOptions = {}): number {
+  const width = resolveWidth(options.width);
+  return r * width + q;
+}
+
+export function fromHexIndex(index: number, options: GeometryOptions = {}): { q: number; r: number } {
+  const width = resolveWidth(options.width);
+  const q = index % width;
+  const r = Math.floor(index / width);
+  return { q, r };
+}
+
+export function intersectTest(
+  ax: number,
+  ay: number,
+  aw: number,
+  ah: number,
+  bx: number,
+  by: number,
+  bw: number,
+  bh: number,
+): boolean {
+  return !(bx > ax + aw || bx + bw < ax || by > ay + ah || by + bh < ay);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export * from './geometry.js';
+export * from './pathfinding.js';

--- a/packages/shared/src/pathfinding.test.ts
+++ b/packages/shared/src/pathfinding.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { findAdjacentHexes } from './geometry.js';
+import { findPath } from './pathfinding.js';
+
+describe('findPath', () => {
+  const width = 6;
+  const height = 6;
+
+  it('returns empty path when start equals destination', () => {
+    expect(findPath(5, 5, { width, height })).toEqual([]);
+  });
+
+  it('finds a viable route around blocked tiles', () => {
+    const blocked = new Set([1, 7, 13, 14]);
+    const start = 0;
+    const dest = width * 2 + 3;
+    const path = findPath(start, dest, {
+      width,
+      height,
+      isBlocked: (index) => blocked.has(index),
+    });
+    expect(path).not.toBeNull();
+    const steps = path!;
+    expect(steps.at(-1)).toBe(dest);
+    let current = start;
+    for (const step of steps) {
+      expect(blocked.has(step)).toBe(false);
+      expect(findAdjacentHexes(current, { width })).toContain(step);
+      current = step;
+    }
+  });
+
+  it('returns null when destination is sealed off', () => {
+    const start = 0;
+    const dest = 8;
+    const blockedNeighbors = new Set(findAdjacentHexes(dest, { width }));
+    const path = findPath(start, dest, {
+      width,
+      height,
+      isBlocked: (index) => blockedNeighbors.has(index),
+    });
+    expect(path).toBeNull();
+  });
+});

--- a/packages/shared/src/pathfinding.ts
+++ b/packages/shared/src/pathfinding.ts
@@ -1,0 +1,95 @@
+import { findAdjacentHexes, heuristicDistance, GeometryOptions } from './geometry.js';
+
+export interface FindPathOptions extends GeometryOptions {
+  height?: number;
+  isBlocked?: (index: number) => boolean;
+}
+
+export function findPath(start: number, dest: number, options: FindPathOptions = {}): number[] | null {
+  if (start === dest) {
+    return [];
+  }
+
+  const neighborsOptions: GeometryOptions = { width: options.width };
+  const isBlocked = options.isBlocked ?? (() => false);
+  const height =
+    typeof options.height === 'number' && Number.isFinite(options.height) && options.height > 0
+      ? Math.trunc(options.height)
+      : undefined;
+  const width =
+    typeof options.width === 'number' && Number.isFinite(options.width) && options.width > 0
+      ? Math.trunc(options.width)
+      : undefined;
+  const maxIndex = typeof height === 'number' && typeof width === 'number' ? height * width - 1 : undefined;
+
+  const closed = new Set<number>();
+  const frontier: number[] = [start];
+  const cameFrom = new Map<number, number>();
+  const gScore = new Map<number, number>();
+  const fScore = new Map<number, number>();
+
+  gScore.set(start, 0);
+  fScore.set(start, heuristicDistance(start, dest, neighborsOptions));
+
+  while (frontier.length > 0) {
+    let currentIndex = 0;
+    let current = frontier[0];
+    for (let i = 1; i < frontier.length; i += 1) {
+      const node = frontier[i];
+      if ((fScore.get(node) ?? Number.POSITIVE_INFINITY) < (fScore.get(current) ?? Number.POSITIVE_INFINITY)) {
+        current = node;
+        currentIndex = i;
+      }
+    }
+
+    if (current === dest) {
+      const path: number[] = [dest];
+      while (cameFrom.has(current)) {
+        current = cameFrom.get(current)!;
+        if (current === start) {
+          break;
+        }
+        path.unshift(current);
+      }
+      return path;
+    }
+
+    frontier.splice(currentIndex, 1);
+    closed.add(current);
+
+    for (const neighbor of findAdjacentHexes(current, neighborsOptions)) {
+      if (neighbor < 0) {
+        continue;
+      }
+      if (typeof maxIndex === 'number' && neighbor > maxIndex) {
+        continue;
+      }
+      if (closed.has(neighbor)) {
+        continue;
+      }
+      if (isBlocked(neighbor)) {
+        closed.add(neighbor);
+        continue;
+      }
+
+      const tentativeG = (gScore.get(current) ?? Number.POSITIVE_INFINITY) +
+        heuristicDistance(current, neighbor, neighborsOptions);
+
+      const existing = gScore.get(neighbor);
+      const hasBetterScore = existing !== undefined && tentativeG >= existing;
+      if (hasBetterScore) {
+        continue;
+      }
+
+      cameFrom.set(neighbor, current);
+      gScore.set(neighbor, tentativeG);
+      fScore.set(neighbor, tentativeG + heuristicDistance(neighbor, dest, neighborsOptions));
+
+      if (!frontier.includes(neighbor)) {
+        frontier.push(neighbor);
+      }
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- port the Fallout hex projection math from jsFO into reusable shared geometry helpers
- implement the jsFO-style A* pathfinding routine with configurable map bounds and blocking
- cover the new helpers with Vitest suites that ensure compatibility with the original ordering and heuristics

## Testing
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dd29374548832cba8795046deffa7d